### PR TITLE
v0.7.1 fix: separate play/pause buttons and correct chapter 1 intro (fixes #11, #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.1] - 2026-05-21
+
+### Fixed
+- Pause button is now always visible as its own distinct control alongside Play — no longer toggling visibility; Play dims when playing, Pause dims when paused (#11)
+- Chapter 1 intro now correctly begins with "Atha Srimad Bhagavad Gita" (not "Om Sri Paramatmane Namah") as the golden first-header, matching the traditional recitation sequence (#12)
+
 ## [0.7.0] - 2026-05-19
 
 ### Added

--- a/data/chapter_01.json
+++ b/data/chapter_01.json
@@ -7,20 +7,11 @@
       "shlokaNum": "",
       "entry": [
         {
-          "startTime": "0.914286",
-          "endTime": "6.25673",
-          "swhtsp": "l",
-          "shlNbr": "00",
-          "sty": "fh",
-          "text": "ओं  श्री  परमात्मने नमः",
-          "iast": "ōṃ  śrī  paramātmanē namaḥ"
-        },
-        {
           "startTime": "0",
           "endTime": "0",
           "swhtsp": "l",
           "shlNbr": "00",
-          "sty": "sh",
+          "sty": "fh",
           "text": "अथ  श्रीमद्भगवद्गीता",
           "iast": "atha  śrīmadbhagavadgītā"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gita-pacer",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gita-pacer",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "devDependencies": {
         "electron": "^35.0.0",
         "electron-builder": "^26.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gita-pacer",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/src/operator.html
+++ b/src/operator.html
@@ -94,6 +94,7 @@ button, select, input {
 }
 button:hover { background: #444; border-color: #666; }
 button:active { transform: scale(0.95); }
+button:disabled { opacity: 0.35; cursor: not-allowed; transform: none; pointer-events: none; }
 select { width: 100%; font-size: 14px; }
 input[type="number"] { width: 70px; text-align: center; }
 
@@ -148,7 +149,7 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
 <div class="section-label">Transport</div>
 <div class="transport">
   <button id="btn-play" title="Play">&#9654;</button>
-  <button id="btn-pause" style="display:none" title="Pause">&#9646;&#9646;</button>
+  <button id="btn-pause" title="Pause" disabled>&#9646;&#9646;</button>
   <button id="btn-reset" title="Reset">&#8634;</button>
   <button id="btn-restart-chapter" title="Restart Chapter">&#8635; Restart</button>
   <button id="btn-next" title="Next page">&#9654;</button>

--- a/src/shared.js
+++ b/src/shared.js
@@ -836,8 +836,8 @@ const animator = (function() {
 
   function play() {
     isPlaying = true;
-    btnPlay.style.display = 'none';
-    btnPause.style.display = '';
+    btnPlay.disabled = true;
+    btnPause.disabled = false;
     advance();
   }
 
@@ -847,8 +847,8 @@ const animator = (function() {
       clearTimeout(timeoutId);
       timeoutId = null;
     }
-    btnPlay.style.display = '';
-    btnPause.style.display = 'none';
+    btnPlay.disabled = false;
+    btnPause.disabled = true;
   }
 
   function reset() {
@@ -879,8 +879,8 @@ const animator = (function() {
     // Past end — auto-advance to next page if available, otherwise stop
     if (currentIndex >= elems.length) {
       isPlaying = false;
-      btnPlay.style.display = '';
-      btnPause.style.display = 'none';
+      btnPlay.disabled = false;
+      btnPause.disabled = true;
       hidePointer();
       // Auto-advance to next page — notify via callback
       if (onAutoAdvance) {
@@ -996,8 +996,8 @@ const animator = (function() {
     // Resume playing if it was playing
     if (state.isPlaying && currentIndex >= 0) {
       isPlaying = true;
-      btnPlay.style.display = 'none';
-      btnPause.style.display = '';
+      btnPlay.disabled = true;
+      btnPause.disabled = false;
       const beats = parseInt(elems[currentIndex].dataset.beats, 10) || 1;
       const lineEndPause = elems[currentIndex].dataset.lineEnd ? 1 : 0;
       timeoutId = setTimeout(advance, (beats + lineEndPause) * getBeatMs());

--- a/src/shared.js
+++ b/src/shared.js
@@ -836,8 +836,8 @@ const animator = (function() {
 
   function play() {
     isPlaying = true;
-    btnPlay.disabled = true;
-    btnPause.disabled = false;
+    if (btnPlay) btnPlay.disabled = true;
+    if (btnPause) btnPause.disabled = false;
     advance();
   }
 
@@ -847,8 +847,8 @@ const animator = (function() {
       clearTimeout(timeoutId);
       timeoutId = null;
     }
-    btnPlay.disabled = false;
-    btnPause.disabled = true;
+    if (btnPlay) btnPlay.disabled = false;
+    if (btnPause) btnPause.disabled = true;
   }
 
   function reset() {
@@ -879,8 +879,8 @@ const animator = (function() {
     // Past end — auto-advance to next page if available, otherwise stop
     if (currentIndex >= elems.length) {
       isPlaying = false;
-      btnPlay.disabled = false;
-      btnPause.disabled = true;
+      if (btnPlay) btnPlay.disabled = false;
+      if (btnPause) btnPause.disabled = true;
       hidePointer();
       // Auto-advance to next page — notify via callback
       if (onAutoAdvance) {
@@ -996,8 +996,8 @@ const animator = (function() {
     // Resume playing if it was playing
     if (state.isPlaying && currentIndex >= 0) {
       isPlaying = true;
-      btnPlay.disabled = true;
-      btnPause.disabled = false;
+      if (btnPlay) btnPlay.disabled = true;
+      if (btnPause) btnPause.disabled = false;
       const beats = parseInt(elems[currentIndex].dataset.beats, 10) || 1;
       const lineEndPause = elems[currentIndex].dataset.lineEnd ? 1 : 0;
       timeoutId = setTimeout(advance, (beats + lineEndPause) * getBeatMs());


### PR DESCRIPTION
## Summary

**Issue #11 — Separate Play and Pause buttons:**
- Pause button is now always visible as its own distinct control (removed `display:none` toggle)
- Play is dimmed/disabled while playing; Pause is dimmed/disabled while paused
- Uses HTML `disabled` attribute + CSS `opacity: 0.35` — buttons are always in frame, state is unambiguous
- Added null guards for `btnPlay`/`btnPause` in `shared.js` (safe when `shared.js` loads in the projector window, which has no transport buttons)

**Issue #12 — Correct chapter 1 intro sequence:**
- Chapter 1 must NOT begin with "Om Sri Paramatmane Namah" — only chapters 2–18 do
- Removed the `fh` entry for "ōṃ śrī paramātmanē namaḥ" from `chapter_01.json`
- Promoted "atha śrīmadbhagavadgītā" from `sty: "sh"` to `sty: "fh"` (rendered in gold as first header)
- Correct sequence is now: **Atha Srimad Bhagavad Gita → Atha Prathamo'dhyayah → Arjuna Visada Yogah**

## Pre-Landing Review
No issues found — contained UI-state changes (display toggles → disabled flags) and a data entry fix. No security surface, no new async paths, no shared-state mutations.

## Plan Completion
- [x] Issue #11: Pause button always visible, Play/Pause use disabled state
- [x] Issue #11: Scenario 6 — repeated Pause taps: `disabled` prevents double-click naturally
- [x] Issue #11: Adversarial finding — null-guard `btnPlay`/`btnPause` for projector window
- [x] Issue #12: Chapter 1 intro starts with "Atha Srimad Bhagavad Gita" (fh)
- [x] Issue #12: 5-second countdown + "Listen to Śruti" already working (existing `playWithCountdown` + projector overlay)
- [x] Issue #12: BPM sync already correct via `getBeatMs()`

## Test plan
- [ ] Open operator — both Play (▶) and Pause (⏸) buttons visible side-by-side
- [ ] Press Play → Play button dims, Pause button is active
- [ ] Press Pause → Pause dims, Play is active
- [ ] Rapid taps on Pause while paused → no jump or accidental resume
- [ ] Load Chapter 1 → first page shows "atha śrīmadbhagavadgītā" in gold (not "Om Sri Paramatmane Namah")
- [ ] Load Chapter 2 → first page shows "ōṃ śrī paramātmanē namaḥ" in gold (unchanged)
- [ ] Press Play on Chapter 1 page 0 → 5-second countdown fires → intro sequence plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)