### PR TITLE
feat: check GitHub releases at startup and show update banner

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,23 @@
-const { app, BrowserWindow, ipcMain, screen, dialog } = require('electron');
+const { app, BrowserWindow, ipcMain, screen, dialog, shell } = require('electron');
 const path = require('path');
+
+const GITHUB_REPO = 'ccsumvid/gita-presentation';
+
+async function checkForUpdates() {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases/latest`, {
+      headers: { 'User-Agent': `gita-pacer/${app.getVersion()}` }
+    });
+    if (!res.ok) return;
+    const data = await res.json();
+    const latest = (data.tag_name || '').replace(/^v/, '');
+    if (latest && latest !== app.getVersion() && operatorWindow) {
+      operatorWindow.webContents.send('update-available', { version: latest, url: data.html_url });
+    }
+  } catch (_) {
+    // network unavailable — silently ignore
+  }
+}
 
 let operatorWindow = null;
 let projectorWindow = null;
@@ -152,8 +170,16 @@ ipcMain.on('close-projector', function() {
   }
 });
 
+// Open external URL (used by update banner)
+ipcMain.on('open-url', function(event, url) {
+  shell.openExternal(url);
+});
+
 // App lifecycle
-app.whenReady().then(createOperatorWindow);
+app.whenReady().then(function() {
+  createOperatorWindow();
+  setTimeout(checkForUpdates, 5000);
+});
 
 app.on('window-all-closed', function() {
   app.quit();

--- a/src/operator.html
+++ b/src/operator.html
@@ -135,9 +135,48 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
 .mode-row { display: flex; gap: 6px; justify-content: center; }
 .mode-btn { flex: 1; }
 .mode-btn.selected { background: #c94; color: #000; border-color: #c94; }
+
+/* Update banner */
+#update-banner {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  background: #0e2a0e;
+  border: 1px solid #2ecc40;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: #2ecc40;
+}
+#update-banner a {
+  color: #2ecc40;
+  text-decoration: underline;
+  cursor: pointer;
+  margin-left: auto;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 13px;
+}
+#update-banner button {
+  background: none;
+  border: none;
+  color: #2ecc40;
+  padding: 0 4px;
+  font-size: 14px;
+  opacity: 0.6;
+}
+#update-banner button:hover { opacity: 1; background: none; }
 </style>
 </head>
 <body>
+
+<!-- Update banner (hidden until a newer GitHub release is detected) -->
+<div id="update-banner">
+  <span id="update-text">Update available</span>
+  <a id="update-link" href="#">Download ↗</a>
+  <button id="update-dismiss" title="Dismiss">&#10006;</button>
+</div>
 
 <!-- Position -->
 <div class="position-bar">
@@ -255,5 +294,29 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
 
 <script src="shared.js"></script>
 <script src="operator.js"></script>
+<script>
+(function() {
+  var banner = document.getElementById('update-banner');
+  var text   = document.getElementById('update-text');
+  var link   = document.getElementById('update-link');
+  var dismiss = document.getElementById('update-dismiss');
+  var releaseUrl = '';
+
+  window.electronAPI.on('update-available', function(info) {
+    releaseUrl = info.url;
+    text.textContent = 'v' + info.version + ' available';
+    banner.style.display = 'flex';
+  });
+
+  link.addEventListener('click', function(e) {
+    e.preventDefault();
+    if (releaseUrl) window.electronAPI.send('open-url', releaseUrl);
+  });
+
+  dismiss.addEventListener('click', function() {
+    banner.style.display = 'none';
+  });
+})();
+</script>
 </body>
 </html>

--- a/src/preload.js
+++ b/src/preload.js
@@ -6,7 +6,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       'render-page', 'syllable-update', 'animation-reset',
       'countdown', 'display-mode', 'spm-change',
       'show-instruction', 'dismiss-instruction',
-      'open-projector', 'close-projector'
+      'open-projector', 'close-projector',
+      'open-url'
     ];
     if (validChannels.includes(channel)) {
       ipcRenderer.send(channel, data);
@@ -17,7 +18,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       'render-page', 'syllable-update', 'animation-reset',
       'countdown', 'display-mode', 'spm-change',
       'show-instruction', 'dismiss-instruction',
-      'projector-status'
+      'projector-status',
+      'update-available'
     ];
     if (validChannels.includes(channel)) {
       ipcRenderer.on(channel, (event, ...args) => callback(...args));


### PR DESCRIPTION
## Summary

- Polls `https://api.github.com/repos/ccsumvid/gita-presentation/releases/latest` 5 seconds after app launch
- If a newer version is found, a green banner appears at the top of the operator window showing the version number
- "Download ↗" link opens the GitHub releases page in the system browser via `shell.openExternal`
- Banner is dismissable with ✕
- No new dependencies — uses Electron's built-in `fetch` (available since Electron 21) and `shell`

## Why no auto-install?

macOS requires code signing + notarization for `autoUpdater.quitAndInstall()` to work. Since the app is distributed unsigned, directing the user to the GitHub releases page is the most reliable cross-platform approach. The banner is unobtrusive and the check is silent on failure (offline, rate-limited, etc).

## Test plan

- [ ] Start the app — no banner should appear (current version matches latest)
- [ ] Temporarily change `app.getVersion()` to an old version (e.g. `0.1.0`) in a local build and verify the banner appears after ~5 seconds
- [ ] Click "Download ↗" — should open the GitHub releases page in the browser
- [ ] Click ✕ — banner dismisses
- [ ] Kill network before launch — app starts normally, no error, no banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)