### PR TITLE
feat(#34): chapter/section selection for the day's parayana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.12.0] - 2026-07-01
+
+### Added
+- **Chapter/section selection** (#34): operator settings now let you pick which sections to chant on a given day — an "include in parayana" checkbox per section, plus Select all/none. **Default is all sections (regular full parayana)** — no selection required. When a subset is chosen, auto-advance follows only the selected sections in canonical order and the parayana starts at the first selected one; manual chapter jumps still reach any section. Persisted across sessions.
+
 ## [0.11.0] - 2026-07-01
 
 Batch of parayana QA follow-ups from Sphoorthi (#27, #34, #37–#48).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gita-pacer",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gita-pacer",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "devDependencies": {
         "electron": "^35.0.0",
         "electron-builder": "^26.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gita-pacer",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/src/operator.html
+++ b/src/operator.html
@@ -410,7 +410,14 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
       </select>
     </div>
 
-    <div class="settings-subtitle">Per-section tempo (SPM) — blank = manual / no default</div>
+    <div class="settings-subtitle">
+      Sections to chant &amp; per-section tempo — checkbox = include in today's parayana
+      (all checked = regular full parayana); SPM blank = manual / no default.
+      <span class="settings-section-actions">
+        <button type="button" id="btn-sections-all">Select all</button>
+        <button type="button" id="btn-sections-none">Select none</button>
+      </span>
+    </div>
     <div id="settings-section-list" class="settings-section-list"></div>
 
     <div class="settings-actions">

--- a/src/operator.js
+++ b/src/operator.js
@@ -23,7 +23,8 @@
     sarvadharmanPauseBeats: 3, // pause between colophon and sarvadharmān slide (mātrās) — #40
     headerBpmDrop: 20,       // internal bpm drop on header slides (= 5 SPM), all chapters — #47
     theme: 'dark',           // projector theme: 'dark' (black bg) or 'light' (white bg) — #37
-    sectionBpm: {}           // chapterId -> internal BPM override; empty = use data defaultBpm
+    sectionBpm: {},          // chapterId -> internal BPM override; empty = use data defaultBpm
+    enabledSections: []      // chapters to chant this parayana (#34); empty = ALL (regular parayana)
   };
 
   function loadChantSettings() {
@@ -40,7 +41,8 @@
       sarvadharmanPauseBeats: CHANT_DEFAULTS.sarvadharmanPauseBeats,
       headerBpmDrop: CHANT_DEFAULTS.headerBpmDrop,
       theme: CHANT_DEFAULTS.theme,
-      sectionBpm: {}
+      sectionBpm: {},
+      enabledSections: []
     };
     try {
       var raw = window.localStorage.getItem('gitaChantSettings');
@@ -65,6 +67,9 @@
                 merged.sectionBpm[k] = parsed.sectionBpm[k];
               }
             }
+          }
+          if (Array.isArray(parsed.enabledSections)) {
+            merged.enabledSections = parsed.enabledSections.filter(function(x) { return typeof x === 'string'; });
           }
         }
       }
@@ -103,6 +108,8 @@
     });
     // Projector theme — dark (black bg) / light (white bg) — #37
     sendToProjector('theme', { theme: chantSettings.theme });
+    // Active parayana subset (#34) — empty array = all chapters (regular parayana).
+    dataLayer.setActiveChapters(chantSettings.enabledSections);
   }
 
   // The tempo the chapter should run at: set on chapter load (defaultBpm or current),
@@ -626,10 +633,12 @@
   // Build the per-section BPM rows once (label + number input keyed by chapterId).
   // Displayed value is SPM = internal bpm / 4 (matches the rest of the UI); we store
   // internal = SPM * 4. Section labels reuse the chapter dropdown's option text.
-  var sectionBpmInputs = {}; // chapterId -> input element
+  var sectionBpmInputs = {};    // chapterId -> BPM input element
+  var sectionEnableInputs = {}; // chapterId -> "include in parayana" checkbox (#34)
   function buildSectionBpmRows() {
     while (settingsSectionList.firstChild) settingsSectionList.removeChild(settingsSectionList.firstChild);
     sectionBpmInputs = {};
+    sectionEnableInputs = {};
     var labelById = {};
     for (var oi = 0; oi < chapterSelect.options.length; oi++) {
       labelById[chapterSelect.options[oi].value] = chapterSelect.options[oi].textContent;
@@ -639,6 +648,15 @@
       var id = order[i];
       var row = document.createElement('div');
       row.className = 'settings-section-row';
+
+      // Include-in-parayana checkbox (#34). All checked = regular full parayana.
+      var chk = document.createElement('input');
+      chk.type = 'checkbox';
+      chk.className = 'settings-section-enable';
+      chk.checked = true;
+      chk.dataset.chapterId = id;
+      chk.title = 'Include this section in the parayana';
+      row.appendChild(chk);
 
       var lbl = document.createElement('span');
       lbl.className = 'settings-section-name';
@@ -655,8 +673,23 @@
       row.appendChild(inp);
 
       sectionBpmInputs[id] = inp;
+      sectionEnableInputs[id] = chk;
       settingsSectionList.appendChild(row);
     }
+  }
+
+  // Resolve enabledSections → the set of checked chapter IDs. Empty array or
+  // "all checked" both mean the regular full parayana.
+  function readEnabledSections() {
+    var ids = [];
+    var order = dataLayer.CHAPTER_ORDER;
+    var allChecked = true;
+    for (var i = 0; i < order.length; i++) {
+      var id = order[i];
+      var chk = sectionEnableInputs[id];
+      if (chk && chk.checked) { ids.push(id); } else { allChecked = false; }
+    }
+    return allChecked ? [] : ids; // [] = all (regular parayana)
   }
 
   // Effective internal BPM for a section: Settings override, else data defaultBpm.
@@ -693,7 +726,25 @@
       var internal = effectiveSectionBpm(id);
       sectionBpmInputs[id].value = (internal === null) ? '' : Math.round(internal / 4);
     }
+    // #34 include checkboxes: empty enabledSections = all sections (regular parayana).
+    var enabled = chantSettings.enabledSections || [];
+    var allOn = enabled.length === 0;
+    for (var eid in sectionEnableInputs) {
+      if (!Object.prototype.hasOwnProperty.call(sectionEnableInputs, eid)) continue;
+      sectionEnableInputs[eid].checked = allOn || enabled.indexOf(eid) >= 0;
+    }
   }
+
+  // #34 Select all / none for the parayana section checkboxes.
+  function setAllSectionsEnabled(on) {
+    for (var id in sectionEnableInputs) {
+      if (Object.prototype.hasOwnProperty.call(sectionEnableInputs, id)) sectionEnableInputs[id].checked = on;
+    }
+  }
+  var btnSectionsAll = document.getElementById('btn-sections-all');
+  var btnSectionsNone = document.getElementById('btn-sections-none');
+  if (btnSectionsAll) btnSectionsAll.addEventListener('click', function() { setAllSectionsEnabled(true); });
+  if (btnSectionsNone) btnSectionsNone.addEventListener('click', function() { setAllSectionsEnabled(false); });
 
   function openSettings() {
     refreshSettingsInputs();
@@ -733,6 +784,9 @@
         chantSettings.sectionBpm[id] = Math.round(spm) * 4;
       }
     }
+
+    // #34 which sections to chant this parayana (empty = all / regular).
+    chantSettings.enabledSections = readEnabledSections();
 
     saveChantSettings();
     applyChantSettings();
@@ -792,6 +846,8 @@
   });
 
   // --- Init ---
-  applyChantSettings();              // push pace config + theme before the first render
-  loadChapter('datta_stavam', true); // start with blank projector until Play
+  applyChantSettings();              // push pace config + theme + active subset (#34) before first render
+  // Start at the first section of the active parayana subset (#34); defaults to
+  // 'datta_stavam' when all sections are enabled (regular parayana).
+  loadChapter(dataLayer.getFirstActiveChapterId() || 'datta_stavam', true);
 })();

--- a/src/shared.js
+++ b/src/shared.js
@@ -575,6 +575,10 @@ const dataLayer = (function() {
   let chapterName = '';
   let currentChapterId = null;
   const cache = {}; // chapterId -> parsed JSON data
+  // Active subset of chapters for this parayana (#34). null = all chapters
+  // (the default regular parayana). When set, next/prev traversal skips
+  // chapters not in the subset, but manual jumps to any chapter still work.
+  let activeChapters = null;
 
   function groupIntoPages(shlokas, chapterLineEndPause) {
     const result = [];
@@ -683,19 +687,43 @@ const dataLayer = (function() {
     return currentChapterId;
   }
 
+  // Set the active parayana subset (#34). Pass an array of chapter IDs to limit
+  // auto-advance to those (canonical order preserved); pass null/empty for all.
+  function setActiveChapters(ids) {
+    if (Array.isArray(ids) && ids.length > 0) {
+      activeChapters = CHAPTER_ORDER.filter(function(c) { return ids.indexOf(c) >= 0; });
+      if (activeChapters.length === 0) activeChapters = null;
+    } else {
+      activeChapters = null;
+    }
+  }
+
+  function isActive(id) {
+    return activeChapters === null || activeChapters.indexOf(id) >= 0;
+  }
+
+  // First chapter of the active subset (where a subset parayana starts).
+  function getFirstActiveChapterId() {
+    return (activeChapters && activeChapters.length) ? activeChapters[0] : CHAPTER_ORDER[0];
+  }
+
   function getNextChapterId() {
     var idx = CHAPTER_ORDER.indexOf(currentChapterId);
-    if (idx >= 0 && idx < CHAPTER_ORDER.length - 1) return CHAPTER_ORDER[idx + 1];
+    for (var i = idx + 1; i < CHAPTER_ORDER.length; i++) {
+      if (isActive(CHAPTER_ORDER[i])) return CHAPTER_ORDER[i];
+    }
     return null;
   }
 
   function getPrevChapterId() {
     var idx = CHAPTER_ORDER.indexOf(currentChapterId);
-    if (idx > 0) return CHAPTER_ORDER[idx - 1];
+    for (var i = idx - 1; i >= 0; i--) {
+      if (isActive(CHAPTER_ORDER[i])) return CHAPTER_ORDER[i];
+    }
     return null;
   }
 
-  return { fetchChapter, getPage, getPageCount, getChapterName, getCurrentChapterId, getNextChapterId, getPrevChapterId, CHAPTER_ORDER };
+  return { fetchChapter, getPage, getPageCount, getChapterName, getCurrentChapterId, getNextChapterId, getPrevChapterId, setActiveChapters, getFirstActiveChapterId, CHAPTER_ORDER };
 })();
 
 // ============================================================


### PR DESCRIPTION
Implements #34 — pick which chapters/sections to chant on a given day, then start.

- Per-section **include checkbox** in operator settings + Select all/none.
- **Default = all sections (regular full parayana)** — no selection required.
- Subset mode: auto-advance follows only selected sections (canonical order), parayana starts at the first selected section; manual dropdown jumps still reach any chapter.
- `dataLayer.setActiveChapters()`, `chantSettings.enabledSections` ([] = all). Traversal unit-tested.

**Pending reporter confirmation (posted on #34):** whether to also filter the chapter dropdown to the subset (option b) or keep all chapters reachable for manual jumps (option a, current). Additive follow-up either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)