### PR TITLE
fix: deep ad-hoc sign macOS bundle so it launches (v0.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.12.2] - 2026-07-01
+
+### Fixed
+- **macOS app still crashed on GUI launch in 0.12.1** — `mac.identity: null` made electron-builder skip signing entirely, leaving the bundle unsigned, and Apple Silicon refuses to launch an unsigned `.app` via Finder. Added a `build/afterPack.js` hook that **deep ad-hoc signs** the bundle during the build (before the DMG is packaged), so the app launches after the normal Gatekeeper approval. Added `scripts/launch-mac.sh` (clears quarantine + opens) for local testing.
+
 ## [0.12.1] - 2026-07-01
 
 ### Fixed

--- a/build/afterPack.js
+++ b/build/afterPack.js
@@ -1,0 +1,24 @@
+// electron-builder afterPack hook.
+//
+// We build with mac.identity=null so electron-builder does NOT sign with the
+// keychain's "Apple Distribution" (App Store) cert — that cert makes macOS kill
+// the app at launch outside the App Store (EXC_BREAKPOINT). But identity=null
+// makes electron-builder skip signing entirely, leaving the .app bundle unsigned,
+// and Apple Silicon refuses to GUI-launch an unsigned bundle (it also crashes).
+//
+// There is no "Developer ID Application" cert available, so we deep AD-HOC sign the
+// bundle here — after it's packed, before the DMG is built — so the app launches
+// (after the normal Gatekeeper "Open Anyway" for downloaded copies). Runs on macOS
+// packs only; no-ops on Windows.
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+exports.default = async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = path.join(context.appOutDir, `${appName}.app`);
+  console.log(`  • afterPack: deep ad-hoc signing ${appName}.app`);
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', appPath], { stdio: 'inherit' });
+  // Sanity check the signature is valid before the DMG is built.
+  execFileSync('codesign', ['--verify', '--deep', '--strict', appPath], { stdio: 'inherit' });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gita-pacer",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gita-pacer",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "devDependencies": {
         "electron": "^35.0.0",
         "electron-builder": "^26.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gita-pacer",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -15,6 +15,7 @@
     "directories": {
       "output": "dist"
     },
+    "afterPack": "build/afterPack.js",
     "files": [
       "main.js",
       "src/**/*",

--- a/scripts/launch-mac.sh
+++ b/scripts/launch-mac.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Launch the freshly-built macOS app locally for testing.
+#
+# The DMG-built app is already deep ad-hoc signed (build/afterPack.js). This just
+# clears the Gatekeeper quarantine attribute (harmless if absent; needed for copies
+# opened from a mounted DMG or downloaded) and opens the app.
+#
+# Usage: scripts/launch-mac.sh [mac-arm64|mac]   (default: mac-arm64)
+set -euo pipefail
+
+ARCH_DIR="${1:-mac-arm64}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP="$(find "$ROOT/dist/$ARCH_DIR" -maxdepth 1 -name '*.app' -type d 2>/dev/null | head -1)"
+
+if [ -z "$APP" ]; then
+  echo "No .app found in dist/$ARCH_DIR — build first (npm run build or scripts/release.sh)."
+  exit 1
+fi
+
+echo "==> Clearing quarantine + launching: $APP"
+xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
+open "$APP"


### PR DESCRIPTION
0.12.1's `identity: null` made electron-builder skip signing entirely → unsigned bundle → Apple Silicon kills it on GUI launch. Added `build/afterPack.js` to deep ad-hoc sign the bundle before DMG packaging. Verified: built app is `Signature=adhoc`, `codesign --verify --deep --strict` passes, launching produces no crash report. Added `scripts/launch-mac.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)