### PR TITLE
Full-screen text box + break timer countdown

### DIFF
--- a/main.js
+++ b/main.js
@@ -136,7 +136,8 @@ var projectorChannels = [
   'render-page', 'syllable-update', 'animation-reset',
   'countdown', 'display-mode', 'spm-change',
   'show-instruction', 'dismiss-instruction',
-  'verse-zoom', 'theme'
+  'verse-zoom', 'theme',
+  'fullscreen-text', 'break-timer'
 ];
 
 projectorChannels.forEach(function(channel) {

--- a/src/operator.html
+++ b/src/operator.html
@@ -205,6 +205,26 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
   white-space: nowrap;
 }
 .settings-section-row input[type="number"] { width: 80px; flex: 0 0 auto; }
+.settings-textarea {
+  width: 100%;
+  min-height: 72px;
+  resize: vertical;
+  background: #222;
+  color: #fff;
+  border: 1px solid #555;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-family: 'Noto Sans', Arial, sans-serif;
+  font-size: 14px;
+}
+.settings-btn-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+.settings-btn-row button { flex: 1; font-size: 13px; padding: 8px 10px; }
+.settings-btn-row button:disabled { opacity: 0.35; }
+.settings-hint { color: #888; font-size: 12px; margin-top: 6px; font-style: italic; }
 .settings-actions {
   display: flex;
   align-items: center;
@@ -383,6 +403,26 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
       </span>
     </div>
     <div id="settings-section-list" class="settings-section-list"></div>
+
+    <div class="settings-subtitle">Full-Screen Text Box</div>
+    <textarea id="set-fstext" class="settings-textarea" placeholder="Announcement for the congregation (multi-line supported)..."></textarea>
+    <div class="settings-btn-row">
+      <button id="btn-fstext-show">Show on projector</button>
+      <button id="btn-fstext-hide">Hide</button>
+      <button id="btn-fstext-clear">Clear text</button>
+    </div>
+    <div class="settings-hint" id="fstext-hint">Shows full screen on the projector. Available only when nothing is playing.</div>
+
+    <div class="settings-subtitle">Break Timer Countdown</div>
+    <div class="settings-grid">
+      <label for="set-break-minutes">Break duration (minutes)</label>
+      <input type="number" id="set-break-minutes" min="1" max="120" step="1">
+    </div>
+    <div class="settings-btn-row">
+      <button id="btn-break-start">Start countdown</button>
+      <button id="btn-break-reset">Reset / hide</button>
+    </div>
+    <div class="settings-hint" id="break-hint">Full-screen MM:SS countdown on the projector; shows "Break Complete" at zero. Startable only when nothing is playing.</div>
 
     <div class="settings-actions">
       <button id="btn-settings-reset" class="settings-reset">Reset to defaults</button>

--- a/src/operator.js
+++ b/src/operator.js
@@ -23,6 +23,8 @@
     sarvadharmanPauseBeats: 3, // pause between colophon and sarvadharmān slide (mātrās) — #40
     headerBpmDrop: 40,       // internal bpm drop on header slides (= 10 BPM), all chapters — #47
     theme: 'dark',           // projector theme: 'dark' (black bg) or 'light' (white bg) — #37
+    fullscreenText: '',      // announcement text for the full-screen text box
+    breakMinutes: 10,        // break timer duration (minutes)
     sectionBpm: {},          // chapterId -> internal BPM override; empty = use data defaultBpm
     enabledSections: []      // chapters to chant this parayana (#34); empty = ALL (regular parayana)
   };
@@ -41,6 +43,8 @@
       sarvadharmanPauseBeats: CHANT_DEFAULTS.sarvadharmanPauseBeats,
       headerBpmDrop: CHANT_DEFAULTS.headerBpmDrop,
       theme: CHANT_DEFAULTS.theme,
+      fullscreenText: CHANT_DEFAULTS.fullscreenText,
+      breakMinutes: CHANT_DEFAULTS.breakMinutes,
       sectionBpm: {},
       enabledSections: []
     };
@@ -61,6 +65,8 @@
           if (typeof parsed.sarvadharmanPauseBeats === 'number') merged.sarvadharmanPauseBeats = parsed.sarvadharmanPauseBeats;
           if (typeof parsed.headerBpmDrop === 'number') merged.headerBpmDrop = parsed.headerBpmDrop;
           if (parsed.theme === 'dark' || parsed.theme === 'light') merged.theme = parsed.theme;
+          if (typeof parsed.fullscreenText === 'string') merged.fullscreenText = parsed.fullscreenText;
+          if (typeof parsed.breakMinutes === 'number') merged.breakMinutes = parsed.breakMinutes;
           if (parsed.sectionBpm && typeof parsed.sectionBpm === 'object') {
             for (var k in parsed.sectionBpm) {
               if (Object.prototype.hasOwnProperty.call(parsed.sectionBpm, k) && typeof parsed.sectionBpm[k] === 'number') {
@@ -767,6 +773,8 @@
     if (fldColophonPause) fldColophonPause.value = chantSettings.colophonPauseSeconds;
     if (fldSarvaPause) fldSarvaPause.value = chantSettings.sarvadharmanPauseBeats;
     if (fldHeaderBpmDrop) fldHeaderBpmDrop.value = chantSettings.headerBpmDrop;
+    if (fldFsText) fldFsText.value = chantSettings.fullscreenText || '';
+    if (fldBreakMinutes) fldBreakMinutes.value = chantSettings.breakMinutes;
     if (fldTheme) fldTheme.value = chantSettings.theme;
     for (var id in sectionBpmInputs) {
       if (!Object.prototype.hasOwnProperty.call(sectionBpmInputs, id)) continue;
@@ -819,6 +827,8 @@
     if (fldColophonPause) chantSettings.colophonPauseSeconds = clampNum(fldColophonPause.value, 0, 10, CHANT_DEFAULTS.colophonPauseSeconds);
     if (fldSarvaPause) chantSettings.sarvadharmanPauseBeats = clampNum(fldSarvaPause.value, 0, 12, CHANT_DEFAULTS.sarvadharmanPauseBeats);
     if (fldHeaderBpmDrop) chantSettings.headerBpmDrop = Math.round(clampNum(fldHeaderBpmDrop.value, 0, 80, CHANT_DEFAULTS.headerBpmDrop));
+    if (fldFsText) chantSettings.fullscreenText = fldFsText.value;
+    if (fldBreakMinutes) chantSettings.breakMinutes = Math.round(clampNum(fldBreakMinutes.value, 1, 120, CHANT_DEFAULTS.breakMinutes));
     if (fldTheme) chantSettings.theme = (fldTheme.value === 'light') ? 'light' : 'dark';
 
     // Per-section BPM: a value present → store internal = SPM*4; blank → clear override.
@@ -882,6 +892,68 @@
     applyChantSettings();
     refreshSettingsInputs();
   }
+
+  // --- Full-Screen Text Box + Break Timer (standalone; projector overlays) ---
+  // Both are usable only while nothing is playing; if playback starts while one
+  // is showing, it is hidden automatically so it never covers live recitation.
+  var fldFsText = document.getElementById('set-fstext');
+  var fldBreakMinutes = document.getElementById('set-break-minutes');
+  var btnFsShow = document.getElementById('btn-fstext-show');
+  var btnFsHide = document.getElementById('btn-fstext-hide');
+  var btnFsClear = document.getElementById('btn-fstext-clear');
+  var btnBreakStart = document.getElementById('btn-break-start');
+  var btnBreakReset = document.getElementById('btn-break-reset');
+  var fsTextShowing = false;
+  var breakTimerShowing = false;
+
+  btnFsShow.addEventListener('click', function() {
+    if (animator.getState().isPlaying) return;
+    var text = (fldFsText.value || '').trim();
+    if (!text) return;
+    chantSettings.fullscreenText = fldFsText.value;
+    saveChantSettings();
+    sendToProjector('fullscreen-text', { text: text });
+    fsTextShowing = true;
+  });
+  btnFsHide.addEventListener('click', function() {
+    sendToProjector('fullscreen-text', { text: null });
+    fsTextShowing = false;
+  });
+  btnFsClear.addEventListener('click', function() {
+    fldFsText.value = '';
+    chantSettings.fullscreenText = '';
+    saveChantSettings();
+  });
+
+  btnBreakStart.addEventListener('click', function() {
+    if (animator.getState().isPlaying) return;
+    var mins = Math.round(clampNum(fldBreakMinutes.value, 1, 120, CHANT_DEFAULTS.breakMinutes));
+    fldBreakMinutes.value = mins;
+    chantSettings.breakMinutes = mins;
+    saveChantSettings();
+    sendToProjector('break-timer', { action: 'start', seconds: mins * 60 });
+    breakTimerShowing = true;
+  });
+  btnBreakReset.addEventListener('click', function() {
+    sendToProjector('break-timer', { action: 'hide' });
+    breakTimerShowing = false;
+  });
+
+  // Enablement poll: disable triggers during playback; auto-hide overlays if
+  // playback starts while one is up.
+  setInterval(function() {
+    var playing = animator.getState().isPlaying;
+    btnFsShow.disabled = playing;
+    btnBreakStart.disabled = playing;
+    if (playing && fsTextShowing) {
+      sendToProjector('fullscreen-text', { text: null });
+      fsTextShowing = false;
+    }
+    if (playing && breakTimerShowing) {
+      sendToProjector('break-timer', { action: 'hide' });
+      breakTimerShowing = false;
+    }
+  }, 500);
 
   buildSectionBpmRows();
   document.getElementById('btn-settings').addEventListener('click', openSettings);

--- a/src/preload.js
+++ b/src/preload.js
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       'countdown', 'display-mode', 'spm-change',
       'show-instruction', 'dismiss-instruction',
       'verse-zoom', 'theme',
+      'fullscreen-text', 'break-timer',
       'open-projector', 'close-projector'
     ];
     if (validChannels.includes(channel)) {
@@ -19,6 +20,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       'countdown', 'display-mode', 'spm-change',
       'show-instruction', 'dismiss-instruction',
       'verse-zoom', 'theme',
+      'fullscreen-text', 'break-timer',
       'projector-status'
     ];
     if (validChannels.includes(channel)) {

--- a/src/projector.html
+++ b/src/projector.html
@@ -176,6 +176,43 @@
       font-size: clamp(10px, 1.2vw, 16px);
       margin-top: 4px;
     }
+    /* Full-screen text box (announcements) + break timer — standalone overlays,
+       above the countdown (100) and instruction card (200). */
+    #fullscreen-text-overlay, #break-timer-overlay {
+      position: fixed;
+      inset: 0;
+      background: var(--bg);
+      display: none;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      z-index: 300;
+      padding: 6vh 6vw;
+      text-align: center;
+    }
+    #fullscreen-text-overlay .fs-text {
+      color: var(--active);
+      font-size: clamp(32px, 5.5vw, 110px);
+      font-weight: 600;
+      line-height: 1.4;
+      white-space: pre-line;
+      max-width: 90vw;
+    }
+    #break-timer-overlay .break-label {
+      color: var(--fg);
+      font-size: clamp(24px, 3.5vw, 64px);
+      margin-bottom: 3vh;
+      letter-spacing: 0.08em;
+    }
+    #break-timer-overlay .break-time {
+      color: var(--active);
+      font-size: clamp(80px, 18vw, 340px);
+      font-weight: bold;
+      font-variant-numeric: tabular-nums;
+      line-height: 1;
+    }
+    #break-timer-overlay.complete .break-label { color: var(--active); }
+    #break-timer-overlay.complete .break-time { font-size: clamp(48px, 9vw, 160px); }
     @media (max-width: 900px) {
       .verse-line { font-size: clamp(12px, 3vw, 36px); margin: 0.5em 0; letter-spacing: 0.1em; }
       #display { padding: 2vh 3vw; }
@@ -189,6 +226,13 @@
   </style>
 </head>
 <body>
+  <div id="fullscreen-text-overlay">
+    <div class="fs-text"></div>
+  </div>
+  <div id="break-timer-overlay">
+    <div class="break-label">Break</div>
+    <div class="break-time">00:00</div>
+  </div>
   <div id="instruction-overlay">
     <div class="instruction-content"></div>
   </div>

--- a/src/projector.js
+++ b/src/projector.js
@@ -163,6 +163,54 @@
     hidePointer(); // reset pointer state so next active syllable snaps cleanly
   });
 
+  // fullscreen-text: operator announcement shown full screen between sections.
+  window.electronAPI.on('fullscreen-text', function(data) {
+    var o = document.getElementById('fullscreen-text-overlay');
+    if (data && data.text) {
+      o.querySelector('.fs-text').textContent = data.text;
+      o.style.display = 'flex';
+    } else {
+      o.style.display = 'none';
+    }
+  });
+
+  // break-timer: full-screen MM:SS countdown for monitor breaks. The projector
+  // ticks locally; the operator starts/hides it. At zero it shows "Break
+  // Complete" until the operator dismisses it.
+  var breakTimerInterval = null;
+  window.electronAPI.on('break-timer', function(data) {
+    var o = document.getElementById('break-timer-overlay');
+    var num = o.querySelector('.break-time');
+    var lbl = o.querySelector('.break-label');
+    if (breakTimerInterval) { clearInterval(breakTimerInterval); breakTimerInterval = null; }
+    if (data && data.action === 'start' && data.seconds > 0) {
+      var remaining = Math.round(data.seconds);
+      var render = function() {
+        var m = Math.floor(remaining / 60), sec = remaining % 60;
+        num.textContent = (m < 10 ? '0' : '') + m + ':' + (sec < 10 ? '0' : '') + sec;
+      };
+      o.classList.remove('complete');
+      lbl.textContent = 'Break';
+      render();
+      o.style.display = 'flex';
+      breakTimerInterval = setInterval(function() {
+        remaining--;
+        if (remaining <= 0) {
+          clearInterval(breakTimerInterval);
+          breakTimerInterval = null;
+          num.textContent = '00:00';
+          lbl.textContent = 'Break Complete';
+          o.classList.add('complete');
+        } else {
+          render();
+        }
+      }, 1000);
+    } else {
+      o.classList.remove('complete');
+      o.style.display = 'none';
+    }
+  });
+
   // verse-zoom: operator-controlled verse text zoom (#34)
   window.electronAPI.on('verse-zoom', function(data) {
     document.documentElement.style.setProperty('--verse-zoom', String(data.scale || 1));


### PR DESCRIPTION
Two new standalone operator features (same batch on the fork), per Spoorthi aunty:

**Full-Screen Text Box** — Settings panel section with a multi-line textarea and Show/Hide/Clear controls; shows the announcement full screen on the projector (large centered themed text). Text persists in settings.

**Break Timer Countdown** — Settings panel section with duration (minutes), Start and Reset/hide; full-screen MM:SS countdown on the projector ticking every second; at zero shows 'Break Complete' until dismissed; never auto-starts the next section.

Both are **gated on playback**: triggers disabled while a section is playing, re-enabled when it stops, and an overlay auto-hides if playback starts — it can never cover live recitation. Independent from Show Instructions (verified unchanged).

**Verified end-to-end on this branch's running app:** multi-line text shows at 70px+; playback auto-hides + disables both triggers, re-enables on pause; text persists; 1-minute timer shows 01:00 and ticks (00:58 at +2 s); completion shows 'Break Complete' at 00:00 until manual dismiss; praṇām instruction card unaffected.