### PR TITLE
Fix frozen tempo defaults + textarea shortcut clash; timer wording/drift

### DIFF
--- a/src/operator.js
+++ b/src/operator.js
@@ -10,6 +10,12 @@
   // --- Chant timing/tempo settings (operator-only, persisted in localStorage) ---
   // The standalone web app (index.html) keeps its own hardcoded defaults; this panel
   // only affects the Electron operator window.
+  // Bumped whenever the team revises the DEFAULT values. Stored settings from an
+  // older revision are migrated on load: per-section tempo overrides are dropped
+  // (they were frozen pre-fill hints, see saveSettings), and pause/slow-down
+  // values still at their OLD defaults are upgraded to the new defaults.
+  var SETTINGS_REV = 2;
+
   var CHANT_DEFAULTS = {
     colophonBpmDrop: 20,     // internal bpm drop on colophon / ending pages
     countdownSeconds: 5,     // pre-play countdown length
@@ -67,7 +73,14 @@
           if (parsed.theme === 'dark' || parsed.theme === 'light') merged.theme = parsed.theme;
           if (typeof parsed.fullscreenText === 'string') merged.fullscreenText = parsed.fullscreenText;
           if (typeof parsed.breakMinutes === 'number') merged.breakMinutes = parsed.breakMinutes;
-          if (parsed.sectionBpm && typeof parsed.sectionBpm === 'object') {
+          var isCurrentRev = parsed.settingsRev === SETTINGS_REV;
+          if (!isCurrentRev) {
+            // Old-revision store: upgrade values still at old defaults (2 was the
+            // ported default, 4 the original pre-port default for uvāca).
+            if (merged.uvacaPauseBeats === 2 || merged.uvacaPauseBeats === 4) merged.uvacaPauseBeats = CHANT_DEFAULTS.uvacaPauseBeats;
+            if (merged.headerBpmDrop === 20) merged.headerBpmDrop = CHANT_DEFAULTS.headerBpmDrop;
+          }
+          if (isCurrentRev && parsed.sectionBpm && typeof parsed.sectionBpm === 'object') {
             for (var k in parsed.sectionBpm) {
               if (Object.prototype.hasOwnProperty.call(parsed.sectionBpm, k) && typeof parsed.sectionBpm[k] === 'number') {
                 merged.sectionBpm[k] = parsed.sectionBpm[k];
@@ -82,6 +95,7 @@
     } catch (e) {
       console.warn('Bad gitaChantSettings — using defaults:', e);
     }
+    merged.settingsRev = SETTINGS_REV;
     return merged;
   }
 
@@ -631,7 +645,7 @@
   // Keyboard shortcuts
   document.addEventListener('keydown', function(e) {
     // Don't intercept if user is typing in an input/select
-    if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') return;
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT' || e.target.tagName === 'TEXTAREA') return;
 
     if (e.code === 'Space') {
       e.preventDefault();
@@ -831,14 +845,20 @@
     if (fldBreakMinutes) chantSettings.breakMinutes = Math.round(clampNum(fldBreakMinutes.value, 1, 120, CHANT_DEFAULTS.breakMinutes));
     if (fldTheme) chantSettings.theme = (fldTheme.value === 'light') ? 'light' : 'dark';
 
-    // Per-section BPM: a value present → store internal = SPM*4; blank → clear override.
+    // Per-section BPM: store an override ONLY when it differs from the data
+    // default — the panel pre-fills every row with the default as a hint, so
+    // storing all filled rows froze the tempo table at first save and later
+    // default revisions never showed through.
     chantSettings.sectionBpm = {};
     for (var id in sectionBpmInputs) {
       if (!Object.prototype.hasOwnProperty.call(sectionBpmInputs, id)) continue;
       var raw = sectionBpmInputs[id].value;
       if (raw !== '' && raw !== null && !isNaN(parseFloat(raw))) {
         var spm = clampNum(raw, 10, 150, 95);
-        chantSettings.sectionBpm[id] = Math.round(spm) * 4;
+        var internal = Math.round(spm) * 4;
+        if (internal !== DATA_DEFAULT_BPM[id]) {
+          chantSettings.sectionBpm[id] = internal;
+        }
       }
     }
 

--- a/src/projector.html
+++ b/src/projector.html
@@ -230,7 +230,7 @@
     <div class="fs-text"></div>
   </div>
   <div id="break-timer-overlay">
-    <div class="break-label">Break</div>
+    <div class="break-label">Starts In</div>
     <div class="break-time">00:00</div>
   </div>
   <div id="instruction-overlay">

--- a/src/projector.js
+++ b/src/projector.js
@@ -184,27 +184,27 @@
     var lbl = o.querySelector('.break-label');
     if (breakTimerInterval) { clearInterval(breakTimerInterval); breakTimerInterval = null; }
     if (data && data.action === 'start' && data.seconds > 0) {
-      var remaining = Math.round(data.seconds);
+      // Deadline-based, not tick-decrement: interval jitter/throttling can then
+      // never accumulate drift over a long break.
+      var deadline = Date.now() + Math.round(data.seconds) * 1000;
       var render = function() {
-        var m = Math.floor(remaining / 60), sec = remaining % 60;
-        num.textContent = (m < 10 ? '0' : '') + m + ':' + (sec < 10 ? '0' : '') + sec;
-      };
-      o.classList.remove('complete');
-      lbl.textContent = 'Break';
-      render();
-      o.style.display = 'flex';
-      breakTimerInterval = setInterval(function() {
-        remaining--;
+        var remaining = Math.max(0, Math.round((deadline - Date.now()) / 1000));
         if (remaining <= 0) {
           clearInterval(breakTimerInterval);
           breakTimerInterval = null;
           num.textContent = '00:00';
-          lbl.textContent = 'Break Complete';
+          lbl.textContent = 'Starting Now';
           o.classList.add('complete');
-        } else {
-          render();
+          return;
         }
-      }, 1000);
+        var m = Math.floor(remaining / 60), sec = remaining % 60;
+        num.textContent = (m < 10 ? '0' : '') + m + ':' + (sec < 10 ? '0' : '') + sec;
+      };
+      o.classList.remove('complete');
+      lbl.textContent = 'Starts In';
+      render();
+      o.style.display = 'flex';
+      breakTimerInterval = setInterval(render, 500);
     } else {
       o.classList.remove('complete');
       o.style.display = 'none';


### PR DESCRIPTION
Three fixes from Spoorthi aunty's live testing (same batch on the fork):

1. **Default tempos looked unimplemented** — Settings Save stored every pre-filled per-section row as an explicit override, freezing the table at first save; new data defaults could never show through. Save now stores an override only when it differs from the data default, and a settings-revision migration heals existing stores (drops the frozen overrides, upgrades pause/slow-down values still at their old defaults, keeps genuine customizations).
2. **Text box rejected spaces** — the operator's global shortcuts (Space=play/pause, R=reset, +/-=tempo) fired while typing; the guard now excludes TEXTAREA.
3. **Break timer** — countdown label 'Starts In', completion 'Starting Now'; countdown switched to deadline-based time so throttled intervals can't accumulate drift over long breaks.

Verified with real CDP keystrokes + seeded old-revision localStorage on this branch's app: migration yields Ch17 at 85 / uvāca 3 / header 40-internal; save stores {} at defaults; 'Tea break at 4 pm!' types verbatim with playback off; second-by-second timer trace exact with 'Starting Now' at zero.