### PR TITLE
Header-before-countdown (Samarpana/Sāram/Ārati); Mahātmyam auto-play after header

### DIFF
--- a/src/operator.js
+++ b/src/operator.js
@@ -439,7 +439,10 @@
   var HARD_STOP_CHAPTER_ENDS = { datta_stavam: true, '9': true, '18': true };
   // Sections that pause after their opening header(s): the first verse page is
   // shown but waits for a manual Start.
-  var STOP_AFTER_HEADER_SECTIONS = { gita_mahatmyam: true, gita_saram: true, gita_arati: true };
+  var STOP_AFTER_HEADER_SECTIONS = { gita_saram: true, gita_arati: true };
+  // Sections whose title header is shown BEFORE the countdown (team flow):
+  // section end -> gap -> title visible -> gap -> countdown -> playback.
+  var HEADER_BEFORE_COUNTDOWN = { kshama_prarthana: true, gita_saram: true, gita_arati: true };
   var hardStopDoneFor = null; // chapter we already hard-stopped at (so Play can continue)
 
   // --- Auto-advance: when animator reaches end of page, go to next and resume ---
@@ -471,9 +474,22 @@
         dismissInstruction();
         var nextId = dataLayer.getNextChapterId();
         if (!nextId) return; // no next chapter — stay stopped
-        await loadChapter(nextId, true); // crosses into next chapter, blanked
+        var headerFirst = HEADER_BEFORE_COUNTDOWN[nextId] === true;
+        await loadChapter(nextId, !headerFirst); // header-first sections load UNBLANKED
         var newChapter = dataLayer.getCurrentChapterId();
         if (newChapter === chapterId) return; // chapter load failed — stay stopped
+        if (headerFirst) {
+          // Samarpana / Gita Sāram / Gita Ārati: the section title is visible now;
+          // let it sit for the chapter gap, THEN countdown, then playback.
+          setTimeout(function() {
+            if (dataLayer.getCurrentChapterId() !== nextId) return; // operator navigated away
+            startCountdown(function() {
+              syncProjectorPage();
+              animator.play();
+            });
+          }, gapMs);
+          return;
+        }
         startCountdown(function() {
           // Reveal page 0 (fh header) and animate it as chanting begins.
           syncProjectorPage();


### PR DESCRIPTION
Two flow changes from Spoorthi aunty (same on the fork):

1. **Header before countdown** for Samarpana, Gita Sāram, Gita Ārati only: section end → gap → section title visible → gap → countdown → playback. Other sections unchanged.
2. **Gita Mahātmyam debug report**: the after-header stop (added earlier at the team's request) read as 'pointer not rendering / playback stops' — per the revised expectation it's removed for Mahātmyam: the header animates with the pointer and auto-play continues into śloka 1. Sāram/Ārati keep their stops.

**Verified live**: Mahātmyam title renders with the pointer and flows into śloka 1 playing; the Samarpana transition shows the 'samarpaṇa' title (no countdown overlay), then the countdown, then playback.