### PR TITLE
Header-first sections: countdown lands directly on the first content page

### DIFF
--- a/src/operator.js
+++ b/src/operator.js
@@ -480,10 +480,17 @@
         if (newChapter === chapterId) return; // chapter load failed — stay stopped
         if (headerFirst) {
           // Samarpana / Gita Sāram / Gita Ārati: the section title is visible now;
-          // let it sit for the chapter gap, THEN countdown, then playback.
+          // let it sit for the chapter gap, THEN countdown, then recitation.
           setTimeout(function() {
             if (dataLayer.getCurrentChapterId() !== nextId) return; // operator navigated away
             startCountdown(function() {
+              // Begin recitation DIRECTLY at the first content page — the title
+              // already had its display time before the countdown (replaying it
+              // here read as "countdown -> header" to the team).
+              var firstContent = 0;
+              var total = dataLayer.getPageCount();
+              while (firstContent < total && dataLayer.getPage(firstContent).isHeader) firstContent++;
+              if (firstContent < total) showPage(firstContent);
               syncProjectorPage();
               animator.play();
             });


### PR DESCRIPTION
Follow-up to #63 per Spoorthi aunty: the sequence still read as 'countdown → header → recitation' because after the countdown, playback restarted at page 0 — the title — replaying it briefly before the ślokas. The countdown callback now skips past the header page(s) and begins recitation directly on the first content page for the three header-first sections.

**Verified** by recording the projector's observable phases through the Mahātmyam → Samarpana transition on this branch: `TITLE → COUNTDOWN → RECITATION (śloka 1, playing)` with no title replay.