### PR TITLE
Datta Stavam pranam cue, text-free pranam card, Listen & Sync rename (v0.13.15)

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,7 +387,7 @@ body {
     <option value="louder">Louder</option>
     <option value="sit_straight">Sit Straight</option>
     <option value="increase_sruti">Increase Sruti</option>
-    <option value="listen_sync">Listen &amp; Sync with Pace Helpers</option>
+    <option value="listen_sync">Listen &amp; Sync with Pace</option>
     <option value="good_job">Good Job</option>
     <option value="decrease_sruti">Decrease Sruti</option>
     <option value="stop">Stop</option>
@@ -1817,15 +1817,19 @@ const ui = (function() {
       (chId === '18' && (page.shlokaNum === '66' || page.shlokaNum === '78')));
     // Folded-hands cue at the start of sloka 1 and sloka 2 of EVERY chapter (#sloka-1-2
     // gif): auto-shown once per entry into the sloka, auto-dismissed after ~2 GIF loops.
-    var slokaGifKey = (page && !page.isHeader && (page.shlokaNum === '1' || page.shlokaNum === '2') &&
-      chId !== '0' && chId !== 'invocation_prayers' && chId !== 'kshama_prarthana')
+    // Datta Stavam: EVERY sloka shows the Pranam GIF instead (team 07-19) —
+    // same trigger/timing as the sloka-1/2 cue, only the card differs.
+    var isDattaSloka = chId === 'datta_stavam';
+    var slokaGifKey = (page && !page.isHeader && (isDattaSloka ||
+      ((page.shlokaNum === '1' || page.shlokaNum === '2') &&
+       chId !== '0' && chId !== 'invocation_prayers' && chId !== 'kshama_prarthana')))
       ? chId + '/' + page.shlokaNum : null;
     if (needsMudra) {
       // Pranam añjali mudra for every mudra overlay site.
       showInstruction('pranam', { corner: true });
       headerInstructionShowing = true;
     } else if (slokaGifKey && slokaGifKey !== lastSlokaGifKey) {
-      showInstruction('folded_hands_anim', { corner: true });
+      showInstruction(isDattaSloka ? 'pranam' : 'folded_hands_anim', { corner: true });
       headerInstructionShowing = true;
       if (slokaGifTimer) clearTimeout(slokaGifTimer);
       var thisGifKey = slokaGifKey;
@@ -2129,11 +2133,11 @@ var INSTRUCTION_DATA = {
   folded_hands_anim: { image: 'img/instructions/folded-hands.png' },
   folded_hands:      { image: 'img/instructions/image7.gif' },
   namaskara_anim:    { image: 'img/instructions/image9.gif' },
-  pranam:            { text: 'Pran\u0101m', image: 'img/instructions/image7.gif' },
+  pranam:            { image: 'img/instructions/image7.gif' },  // GIF only — no text label per team 07-19
   louder:            { text: 'Increase Volume \uD83D\uDD0A', image: 'img/instructions/increase-volume.gif', autoDismissMs: 10000 },
   sit_straight:      { text: 'Sit Straight', image: 'img/instructions/image9.gif' },
   increase_sruti:    { text: 'Increase Sruti', image: 'img/instructions/shruti-increase.png' },
-  listen_sync:       { text: 'Listen and Sync\nwith Pace Helpers' },
+  listen_sync:       { text: 'Listen & Sync\nwith Pace' },
   good_job:          { image: 'img/instructions/image12.gif' },
   decrease_sruti:    { text: 'Decrease Sruti', image: 'img/instructions/image8.gif' },
   stop:              { text: 'STOP', color: '#ff4444' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gita-pacer",
-  "version": "0.13.13",
+  "version": "0.13.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gita-pacer",
-      "version": "0.13.13",
+      "version": "0.13.15",
       "devDependencies": {
         "electron": "^35.0.0",
         "electron-builder": "^26.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gita-pacer",
-  "version": "0.13.13",
+  "version": "0.13.15",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/src/operator.html
+++ b/src/operator.html
@@ -328,7 +328,7 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
     <option value="sitting_placement">Sitting Placement</option>
     <option value="starting_soon">Parayana Starting Soon</option>
     <option value="stop">Stop</option>
-    <option value="listen_sync">Listen &amp; Sync with Pace Helpers</option>
+    <option value="listen_sync">Listen &amp; Sync with Pace</option>
     <option value="folded_hands">Folded Hands</option>
     <option value="pranam">Pranām</option>
     <option value="sit_straight">Sit Straight</option>

--- a/src/operator.js
+++ b/src/operator.js
@@ -163,11 +163,11 @@
     folded_hands:      { image: '../img/instructions/folded-hands.png' },
     folded_hands_anim: { image: '../img/instructions/folded-hands.png' },
     namaskara_anim:    { image: '../img/instructions/image9.gif' },
-    pranam:            { text: 'Pran\u0101m', image: '../img/instructions/image7.gif' },
+    pranam:            { image: '../img/instructions/image7.gif' },  // GIF only \u2014 no text label per team 07-19
     sit_straight:      { text: 'Sit Straight', image: '../img/instructions/image3.gif' },
     increase_sruti:    { image: '../img/instructions/shruti-increase.png' },
     increase_volume:   { text: 'Increase Volume \uD83D\uDD0A', image: '../img/instructions/increase-volume.gif', autoDismissMs: 10000 },
-    listen_sync:       { text: 'Listen and Sync\nwith Pace Helpers' },
+    listen_sync:       { text: 'Listen & Sync\nwith Pace' },
     good_job:          { image: '../img/instructions/image6.gif' },
     decrease_sruti:    { image: '../img/instructions/image4.jpeg', image2: '../img/instructions/image5.gif', arrow: 'down' },
     stop:              { text: 'STOP', color: '#ff4444' },
@@ -316,8 +316,12 @@
     // don't replay it; re-entering the sloka later does), auto-dismissed after
     // ~2 GIF loops or on leaving the page.
     // (No cue for Dhyana, Invocation Prayers, or Samarpana per the team.)
-    var slokaGifKey = (page && !page.isHeader && (page.shlokaNum === '1' || page.shlokaNum === '2') &&
-      chId !== '0' && chId !== 'invocation_prayers' && chId !== 'kshama_prarthana')
+    // Datta Stavam: EVERY sloka shows the Pranam GIF instead (team 07-19) —
+    // same trigger/timing as the sloka-1/2 cue, only the card differs.
+    var isDattaSloka = chId === 'datta_stavam';
+    var slokaGifKey = (page && !page.isHeader && (isDattaSloka ||
+      ((page.shlokaNum === '1' || page.shlokaNum === '2') &&
+       chId !== '0' && chId !== 'invocation_prayers' && chId !== 'kshama_prarthana')))
       ? chId + '/' + page.shlokaNum : null;
     if (needsMudra) {
       // Pranam añjali mudra for every mudra overlay site.
@@ -326,7 +330,7 @@
       instructionShowing = true;
       headerInstructionShowing = true;
     } else if (slokaGifKey && slokaGifKey !== lastSlokaGifKey) {
-      sendToProjector('show-instruction', INSTRUCTION_DATA['folded_hands_anim']);
+      sendToProjector('show-instruction', INSTRUCTION_DATA[isDattaSloka ? 'pranam' : 'folded_hands_anim']);
       instructionShowing = true;
       headerInstructionShowing = true;   // auto card — auto-dismissed on other pages
       if (slokaGifTimer) clearTimeout(slokaGifTimer);


### PR DESCRIPTION
Three team-requested changes (2026-07-20):

1. **Datta Stavam**: every śloka now shows the Pranam GIF (replaces the folded-hands cue on ślokas 1–2). Same trigger/auto-dismiss mechanics as the existing śloka-1/2 cue.
2. **Pranam card**: text label removed — GIF only, everywhere the card appears (headers, colophons, sarvadharmān, 18.66/18.78, manual menu).
3. **Rename**: 'Listen and Sync with Pace Helpers' → 'Listen & Sync with Pace' (card + operator dropdown).

Mirrored in the web build (index.html). Verified via CDP-driven E2E on the projector DOM (7/7): Datta ślokas all show the text-free GIF; Gita chapters, Dhyana/Invocation/Samarpana cues unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhJ3cyLrFuGiRiBe9oCFPv