### PR TITLE
Revert countdown 5s → 3s (keep default at 5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@ body {
   <div id="pace-indicator"></div>
   <div id="countdown-overlay">
     <div class="countdown-label">Listen to Sruti</div>
-    <div class="countdown-number">3</div>
+    <div class="countdown-number">5</div>
   </div>
   <div id="pointer" style="display:none">&#128071;</div>
   <div id="verse-container-a"></div>
@@ -1942,7 +1942,7 @@ const ui = (function() {
     var countdownNumber = countdownOverlay.querySelector('.countdown-number');
     countdownOverlay.style.display = 'flex';
     broadcastState();
-    var count = 3;  // team 07-24 (was 5)
+    var count = 5;
     countdownNumber.textContent = count;
     var interval = setInterval(function() {
       count--;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gita-pacer",
-  "version": "0.13.16",
+  "version": "0.13.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gita-pacer",
-      "version": "0.13.16",
+      "version": "0.13.15",
       "devDependencies": {
         "electron": "^35.0.0",
         "electron-builder": "^26.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gita-pacer",
-  "version": "0.13.16",
+  "version": "0.13.15",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/src/operator.js
+++ b/src/operator.js
@@ -14,11 +14,11 @@
   // older revision are migrated on load: per-section tempo overrides are dropped
   // (they were frozen pre-fill hints, see saveSettings), and pause/slow-down
   // values still at their OLD defaults are upgraded to the new defaults.
-  var SETTINGS_REV = 3;
+  var SETTINGS_REV = 2;
 
   var CHANT_DEFAULTS = {
     colophonBpmDrop: 20,     // internal bpm drop on colophon / ending pages
-    countdownSeconds: 3,     // pre-play countdown length — team 07-24 (was 5)
+    countdownSeconds: 5,     // pre-play countdown length
     chapterGapSeconds: 3,    // gap between chapters before the countdown
     verseZoom: 100,          // projector verse-text zoom (%) — #34
     headerPauseBeats: 3,     // pause (mātrās) after each header line — #36.1
@@ -82,7 +82,6 @@
             // ported default, 4 the original pre-port default for uvāca).
             if (merged.uvacaPauseBeats === 2 || merged.uvacaPauseBeats === 4) merged.uvacaPauseBeats = CHANT_DEFAULTS.uvacaPauseBeats;
             if (merged.headerBpmDrop === 20) merged.headerBpmDrop = CHANT_DEFAULTS.headerBpmDrop;
-            if (merged.countdownSeconds === 5) merged.countdownSeconds = CHANT_DEFAULTS.countdownSeconds;  // 5 → 3, team 07-24
           }
           if (isCurrentRev && parsed.sectionBpm && typeof parsed.sectionBpm === 'object') {
             for (var k in parsed.sectionBpm) {


### PR DESCRIPTION
Team decision 2026-07-24: keep the default countdown at 5 seconds — operators who want 3 can set it in Settings → Countdown, which already exists. Reverts PR #69; restores v0.13.15 behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhJ3cyLrFuGiRiBe9oCFPv