### PR TITLE
Pacing versions A/B/C: per-syllable timing, matra stars, Saram/Arati content (v0.13.20)

### DIFF
--- a/data/gita_arati.json
+++ b/data/gita_arati.json
@@ -65,37 +65,28 @@
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "2",
-      "entry": [
+        },
         {
           "text": "mayya  kāmāsakti  harā |",
           "iast": "mayya  kāmāsakti  harā |",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "2",
-      "entry": [
+        },
         {
           "text": "tattvajñāna-vikāśini",
           "iast": "tattvajñāna-vikāśini",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ],
-      "repeat": 2
-    },
-    {
-      "shlokaNum": "2",
-      "entry": [
+        },
+        {
+          "text": "tattvajñāna-vikāśini",
+          "iast": "tattvajñāna-vikāśini",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
+        },
         {
           "text": "vidyā  brahma  parā || ōm  jaya ||",
           "iast": "vidyā  brahma  parā || ōm  jaya ||",
@@ -114,37 +105,28 @@
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "3",
-      "entry": [
+        },
         {
           "text": "mayya  nirmala  malahārī |",
           "iast": "mayya  nirmala  malahārī |",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "3",
-      "entry": [
+        },
         {
           "text": "śaraṇa-rahasya-pradāyini",
           "iast": "śaraṇa-rahasya-pradāyini",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ],
-      "repeat": 2
-    },
-    {
-      "shlokaNum": "3",
-      "entry": [
+        },
+        {
+          "text": "śaraṇa-rahasya-pradāyini",
+          "iast": "śaraṇa-rahasya-pradāyini",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
+        },
         {
           "text": "saba  vidhi  sukhakārī || ōm  jaya ||",
           "iast": "saba  vidhi  sukhakārī || ōm  jaya ||",
@@ -163,37 +145,28 @@
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "4",
-      "entry": [
+        },
         {
           "text": "mayya  kāriṇi  mōda  sadā |",
           "iast": "mayya  kāriṇi  mōda  sadā |",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "4",
-      "entry": [
+        },
         {
           "text": "bhava-bhaya-hāriṇi  tāriṇi",
           "iast": "bhava-bhaya-hāriṇi  tāriṇi",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ],
-      "repeat": 2
-    },
-    {
-      "shlokaNum": "4",
-      "entry": [
+        },
+        {
+          "text": "bhava-bhaya-hāriṇi  tāriṇi",
+          "iast": "bhava-bhaya-hāriṇi  tāriṇi",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
+        },
         {
           "text": "paramānandapradā || ōm  jaya ||",
           "iast": "paramānandapradā || ōm  jaya ||",
@@ -212,37 +185,28 @@
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "5",
-      "entry": [
+        },
         {
           "text": "mayya  nāśini  tama-rajanī |",
           "iast": "mayya  nāśini  tama-rajanī |",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "5",
-      "entry": [
+        },
         {
           "text": "daivī  sadguṇadāyini",
           "iast": "daivī  sadguṇadāyini",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ],
-      "repeat": 2
-    },
-    {
-      "shlokaNum": "5",
-      "entry": [
+        },
+        {
+          "text": "daivī  sadguṇadāyini",
+          "iast": "daivī  sadguṇadāyini",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
+        },
         {
           "text": "hari-rasikā  sajanī || ōm  jaya ||",
           "iast": "hari-rasikā  sajanī || ōm  jaya ||",
@@ -261,37 +225,28 @@
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "6",
-      "entry": [
+        },
         {
           "text": "mayya  hari-mukha  kī  vāṇī |",
           "iast": "mayya  hari-mukha  kī  vāṇī |",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "6",
-      "entry": [
+        },
         {
           "text": "sakala  śāstra  kī  svāmini",
           "iast": "sakala  śāstra  kī  svāmini",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ],
-      "repeat": 2
-    },
-    {
-      "shlokaNum": "6",
-      "entry": [
+        },
+        {
+          "text": "sakala  śāstra  kī  svāmini",
+          "iast": "sakala  śāstra  kī  svāmini",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
+        },
         {
           "text": "śrutiyō  kī  rānī || ōm  jaya ||",
           "iast": "śrutiyō  kī  rānī || ōm  jaya ||",
@@ -310,37 +265,28 @@
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "7",
-      "entry": [
+        },
         {
           "text": "mayya  mātu  kr̥pā  kījai |",
           "iast": "mayya  mātu  kr̥pā  kījai |",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ]
-    },
-    {
-      "shlokaNum": "7",
-      "entry": [
+        },
         {
           "text": "hari-pada-prēma  pradāyini",
           "iast": "hari-pada-prēma  pradāyini",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
-        }
-      ],
-      "repeat": 2
-    },
-    {
-      "shlokaNum": "7",
-      "entry": [
+        },
+        {
+          "text": "hari-pada-prēma  pradāyini",
+          "iast": "hari-pada-prēma  pradāyini",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
+        },
         {
           "text": "apanō  kara  lījai || ōm  jaya ||",
           "iast": "apanō  kara  lījai || ōm  jaya ||",

--- a/data/gita_arati.json
+++ b/data/gita_arati.json
@@ -48,9 +48,16 @@
           "sty": ""
         },
         {
-          "text": "sundara  supunītē || ōm  jaya ||",
-          "iast": "sundara  supunītē || ōm  jaya ||",
+          "text": "sundara  supunītē",
+          "iast": "sundara  supunītē",
           "swhtsp": "",
+          "shlNbr": "00",
+          "sty": ""
+        },
+        {
+          "text": "ōm  jaya  bhagavadgītē",
+          "iast": "ōm  jaya  bhagavadgītē",
+          "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
         }
@@ -88,8 +95,8 @@
           "sty": ""
         },
         {
-          "text": "vidyā  brahma  parā || ōm  jaya ||",
-          "iast": "vidyā  brahma  parā || ōm  jaya ||",
+          "text": "vidyā  brahma  parā",
+          "iast": "vidyā  brahma  parā",
           "swhtsp": "",
           "shlNbr": "00",
           "sty": ""
@@ -135,8 +142,8 @@
           "sty": ""
         },
         {
-          "text": "saba  vidhi  sukhakārī || ōm  jaya ||",
-          "iast": "saba  vidhi  sukhakārī || ōm  jaya ||",
+          "text": "saba  vidhi  sukhakārī",
+          "iast": "saba  vidhi  sukhakārī",
           "swhtsp": "",
           "shlNbr": "00",
           "sty": ""
@@ -182,8 +189,8 @@
           "sty": ""
         },
         {
-          "text": "paramānandapradā || ōm  jaya ||",
-          "iast": "paramānandapradā || ōm  jaya ||",
+          "text": "paramānandapradā",
+          "iast": "paramānandapradā",
           "swhtsp": "",
           "shlNbr": "00",
           "sty": ""
@@ -229,8 +236,8 @@
           "sty": ""
         },
         {
-          "text": "hari-rasikā  sajanī || ōm  jaya ||",
-          "iast": "hari-rasikā  sajanī || ōm  jaya ||",
+          "text": "hari-rasikā  sajanī",
+          "iast": "hari-rasikā  sajanī",
           "swhtsp": "",
           "shlNbr": "00",
           "sty": ""
@@ -276,8 +283,8 @@
           "sty": ""
         },
         {
-          "text": "śrutiyō  kī  rānī || ōm  jaya ||",
-          "iast": "śrutiyō  kī  rānī || ōm  jaya ||",
+          "text": "śrutiyō  kī  rānī",
+          "iast": "śrutiyō  kī  rānī",
           "swhtsp": "",
           "shlNbr": "00",
           "sty": ""
@@ -323,8 +330,8 @@
           "sty": ""
         },
         {
-          "text": "apanō  kara  lījai || ōm  jaya ||",
-          "iast": "apanō  kara  lījai || ōm  jaya ||",
+          "text": "apanō  kara  lījai",
+          "iast": "apanō  kara  lījai",
           "swhtsp": "",
           "shlNbr": "00",
           "sty": ""

--- a/data/gita_arati.json
+++ b/data/gita_arati.json
@@ -93,6 +93,13 @@
           "swhtsp": "",
           "shlNbr": "00",
           "sty": ""
+        },
+        {
+          "text": "ōm  jaya  bhagavadgītē",
+          "iast": "ōm  jaya  bhagavadgītē",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
         }
       ]
     },
@@ -131,6 +138,13 @@
           "text": "saba  vidhi  sukhakārī || ōm  jaya ||",
           "iast": "saba  vidhi  sukhakārī || ōm  jaya ||",
           "swhtsp": "",
+          "shlNbr": "00",
+          "sty": ""
+        },
+        {
+          "text": "ōm  jaya  bhagavadgītē",
+          "iast": "ōm  jaya  bhagavadgītē",
+          "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
         }
@@ -173,6 +187,13 @@
           "swhtsp": "",
           "shlNbr": "00",
           "sty": ""
+        },
+        {
+          "text": "ōm  jaya  bhagavadgītē",
+          "iast": "ōm  jaya  bhagavadgītē",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
         }
       ]
     },
@@ -211,6 +232,13 @@
           "text": "hari-rasikā  sajanī || ōm  jaya ||",
           "iast": "hari-rasikā  sajanī || ōm  jaya ||",
           "swhtsp": "",
+          "shlNbr": "00",
+          "sty": ""
+        },
+        {
+          "text": "ōm  jaya  bhagavadgītē",
+          "iast": "ōm  jaya  bhagavadgītē",
+          "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
         }
@@ -253,6 +281,13 @@
           "swhtsp": "",
           "shlNbr": "00",
           "sty": ""
+        },
+        {
+          "text": "ōm  jaya  bhagavadgītē",
+          "iast": "ōm  jaya  bhagavadgītē",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
         }
       ]
     },
@@ -291,6 +326,13 @@
           "text": "apanō  kara  lījai || ōm  jaya ||",
           "iast": "apanō  kara  lījai || ōm  jaya ||",
           "swhtsp": "",
+          "shlNbr": "00",
+          "sty": ""
+        },
+        {
+          "text": "ōm  jaya  bhagavadgītē",
+          "iast": "ōm  jaya  bhagavadgītē",
+          "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""
         }

--- a/data/gita_arati.json
+++ b/data/gita_arati.json
@@ -41,6 +41,13 @@
           "sty": ""
         },
         {
+          "text": "hari-hiya  kamala-vihāriṇi",
+          "iast": "hari-hiya  kamala-vihāriṇi",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
+        },
+        {
           "text": "sundara  supunītē || ōm  jaya ||",
           "iast": "sundara  supunītē || ōm  jaya ||",
           "swhtsp": "",
@@ -356,6 +363,13 @@
         {
           "text": "maiyā  jaya  bhagavadgītē |",
           "iast": "maiyā  jaya  bhagavadgītē |",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
+        },
+        {
+          "text": "hari-hiya  kamala-vihāriṇi",
+          "iast": "hari-hiya  kamala-vihāriṇi",
           "swhtsp": "l",
           "shlNbr": "00",
           "sty": ""

--- a/data/gita_arati.json
+++ b/data/gita_arati.json
@@ -2,6 +2,7 @@
   "name": "gītā ārati",
   "iastName": "gītā ārati",
   "chapterNum": "gita_arati",
+  "defaultBpm": 320,
   "shloka": [
     {
       "shlokaNum": "",

--- a/data/gita_arati.json
+++ b/data/gita_arati.json
@@ -334,7 +334,21 @@
           "shlNbr": "00",
           "sty": ""
         }
-      ]
+      ],
+      "repeat": 2
+    },
+    {
+      "shlokaNum": "pallavi",
+      "entry": [
+        {
+          "text": "ōm  jaya  bhagavadgītē",
+          "iast": "ōm  jaya  bhagavadgītē",
+          "swhtsp": "l",
+          "shlNbr": "00",
+          "sty": ""
+        }
+      ],
+      "repeat": 3
     }
   ]
 }

--- a/data/gita_arati.json
+++ b/data/gita_arati.json
@@ -377,8 +377,8 @@
           "sty": ""
         },
         {
-          "text": "sundara  supunītē || ōm  jaya ||",
-          "iast": "sundara  supunītē || ōm  jaya ||",
+          "text": "sundara  supunītē",
+          "iast": "sundara  supunītē",
           "swhtsp": "",
           "shlNbr": "00",
           "sty": ""

--- a/data/gita_saram.json
+++ b/data/gita_saram.json
@@ -2,6 +2,7 @@
   "name": "gītāsāram",
   "iastName": "gītāsāram",
   "chapterNum": "gita_saram",
+  "defaultBpm": 320,
   "shloka": [
     {
       "shlokaNum": "",

--- a/main.js
+++ b/main.js
@@ -136,7 +136,7 @@ var projectorChannels = [
   'render-page', 'syllable-update', 'animation-reset',
   'countdown', 'display-mode', 'spm-change',
   'show-instruction', 'dismiss-instruction',
-  'verse-zoom', 'theme',
+  'verse-zoom', 'theme', 'pace-config',
   'fullscreen-text', 'break-timer'
 ];
 

--- a/src/operator.html
+++ b/src/operator.html
@@ -387,14 +387,14 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
       <label for="set-header-bpm-drop">Header slowdown (BPM drop)</label>
       <input type="number" id="set-header-bpm-drop" min="0" max="80" step="1">
 
-      <label for="set-header-word-gap">Header word gap (ms)</label>
-      <input type="number" id="set-header-word-gap" min="0" max="500" step="1">
-
-      <label for="set-per-syllable">Per-syllable pointer timing (test)</label>
-      <select id="set-per-syllable">
-        <option value="on">On (pointer follows guru/laghu rhythm)</option>
-        <option value="off">Off (even glide — previous behavior)</option>
+      <label for="set-pacing-version">Pacing version</label>
+      <select id="set-pacing-version">
+        <option value="A">A — Parayana (even glide, as at the event)</option>
+        <option value="B">B — Experimental (guru/laghu rhythm)</option>
       </select>
+
+      <label for="set-header-word-gap">Header word gap (ms) — version B</label>
+      <input type="number" id="set-header-word-gap" min="0" max="500" step="1">
 
       <label for="set-saram-arati-cd">Countdown for Gita Sāram &amp; Ārati</label>
       <select id="set-saram-arati-cd">

--- a/src/operator.html
+++ b/src/operator.html
@@ -390,7 +390,8 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
       <label for="set-pacing-version">Pacing version</label>
       <select id="set-pacing-version">
         <option value="A">A — Parayana (even glide, as at the event)</option>
-        <option value="B">B — Experimental (guru/laghu rhythm)</option>
+        <option value="B">B — Guru/laghu rhythm (pointer dwells)</option>
+        <option value="C">C — Mātrā stars (constant pointer motion)</option>
       </select>
 
       <label for="set-header-word-gap">Header word gap (ms) — version B</label>

--- a/src/operator.html
+++ b/src/operator.html
@@ -387,6 +387,9 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
       <label for="set-header-bpm-drop">Header slowdown (BPM drop)</label>
       <input type="number" id="set-header-bpm-drop" min="0" max="80" step="1">
 
+      <label for="set-header-word-gap">Header word gap (ms)</label>
+      <input type="number" id="set-header-word-gap" min="0" max="500" step="1">
+
       <label for="set-per-syllable">Per-syllable pointer timing (test)</label>
       <select id="set-per-syllable">
         <option value="on">On (pointer follows guru/laghu rhythm)</option>

--- a/src/operator.html
+++ b/src/operator.html
@@ -387,6 +387,12 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
       <label for="set-header-bpm-drop">Header slowdown (BPM drop)</label>
       <input type="number" id="set-header-bpm-drop" min="0" max="80" step="1">
 
+      <label for="set-per-syllable">Per-syllable pointer timing (test)</label>
+      <select id="set-per-syllable">
+        <option value="on">On (pointer follows guru/laghu rhythm)</option>
+        <option value="off">Off (even glide — previous behavior)</option>
+      </select>
+
       <label for="set-saram-arati-cd">Countdown for Gita Sāram &amp; Ārati</label>
       <select id="set-saram-arati-cd">
         <option value="on">On (countdown before recitation)</option>

--- a/src/operator.js
+++ b/src/operator.js
@@ -29,6 +29,7 @@
     sarvadharmanPauseBeats: 3, // pause between colophon and sarvadharmān slide (mātrās) — #40
     headerBpmDrop: 40,       // internal bpm drop on header slides (= 10 BPM), all chapters — #47
     saramAratiCountdown: true, // countdown before Gita Sāram / Ārati recitation (OFF = header -> recitation directly)
+    perSyllableTiming: true, // Case 2 (team 07-30): pointer dwells per guru/laghu weight; OFF = line-average glide
     theme: 'dark',           // projector theme: 'dark' (black bg) or 'light' (white bg) — #37
     fullscreenText: '',      // announcement text for the full-screen text box
     breakMinutes: 10,        // break timer duration (minutes)
@@ -50,6 +51,7 @@
       sarvadharmanPauseBeats: CHANT_DEFAULTS.sarvadharmanPauseBeats,
       headerBpmDrop: CHANT_DEFAULTS.headerBpmDrop,
       saramAratiCountdown: CHANT_DEFAULTS.saramAratiCountdown,
+      perSyllableTiming: CHANT_DEFAULTS.perSyllableTiming,
       theme: CHANT_DEFAULTS.theme,
       fullscreenText: CHANT_DEFAULTS.fullscreenText,
       breakMinutes: CHANT_DEFAULTS.breakMinutes,
@@ -73,6 +75,7 @@
           if (typeof parsed.sarvadharmanPauseBeats === 'number') merged.sarvadharmanPauseBeats = parsed.sarvadharmanPauseBeats;
           if (typeof parsed.headerBpmDrop === 'number') merged.headerBpmDrop = parsed.headerBpmDrop;
           if (typeof parsed.saramAratiCountdown === 'boolean') merged.saramAratiCountdown = parsed.saramAratiCountdown;
+          if (typeof parsed.perSyllableTiming === 'boolean') merged.perSyllableTiming = parsed.perSyllableTiming;
           if (parsed.theme === 'dark' || parsed.theme === 'light') merged.theme = parsed.theme;
           if (typeof parsed.fullscreenText === 'string') merged.fullscreenText = parsed.fullscreenText;
           if (typeof parsed.breakMinutes === 'number') merged.breakMinutes = parsed.breakMinutes;
@@ -128,7 +131,8 @@
       headerPauseBeats: chantSettings.headerPauseBeats,
       anustubhBeats: chantSettings.anustubhBeats,
       tristubhBeats: chantSettings.tristubhBeats,
-      uvacaPauseBeats: chantSettings.uvacaPauseBeats
+      uvacaPauseBeats: chantSettings.uvacaPauseBeats,
+      perSyllableTiming: chantSettings.perSyllableTiming
     });
     // Projector theme — dark (black bg) / light (white bg) — #37
     sendToProjector('theme', { theme: chantSettings.theme });
@@ -1036,6 +1040,8 @@
     if (fldHeaderBpmDrop) fldHeaderBpmDrop.value = chantSettings.headerBpmDrop;
     var fldSaramCd = document.getElementById('set-saram-arati-cd');
     if (fldSaramCd) fldSaramCd.value = chantSettings.saramAratiCountdown ? 'on' : 'off';
+    var fldPerSyl = document.getElementById('set-per-syllable');
+    if (fldPerSyl) fldPerSyl.value = chantSettings.perSyllableTiming ? 'on' : 'off';
     if (fldFsText) fldFsText.value = chantSettings.fullscreenText || '';
     if (fldBreakMinutes) fldBreakMinutes.value = chantSettings.breakMinutes;
     if (fldTheme) fldTheme.value = chantSettings.theme;
@@ -1092,6 +1098,8 @@
     if (fldHeaderBpmDrop) chantSettings.headerBpmDrop = Math.round(clampNum(fldHeaderBpmDrop.value, 0, 80, CHANT_DEFAULTS.headerBpmDrop));
     var fldSaramCdS = document.getElementById('set-saram-arati-cd');
     if (fldSaramCdS) chantSettings.saramAratiCountdown = fldSaramCdS.value !== 'off';
+    var fldPerSylS = document.getElementById('set-per-syllable');
+    if (fldPerSylS) chantSettings.perSyllableTiming = fldPerSylS.value !== 'off';
     if (fldFsText) chantSettings.fullscreenText = fldFsText.value;
     if (fldBreakMinutes) chantSettings.breakMinutes = Math.round(clampNum(fldBreakMinutes.value, 1, 120, CHANT_DEFAULTS.breakMinutes));
     if (fldTheme) chantSettings.theme = (fldTheme.value === 'light') ? 'light' : 'dark';

--- a/src/operator.js
+++ b/src/operator.js
@@ -30,6 +30,7 @@
     headerBpmDrop: 40,       // internal bpm drop on header slides (= 10 BPM), all chapters — #47
     saramAratiCountdown: true, // countdown before Gita Sāram / Ārati recitation (OFF = header -> recitation directly)
     perSyllableTiming: true, // Case 2 (team 07-30): pointer dwells per guru/laghu weight; OFF = line-average glide
+    headerWordGapMs: 2,      // pause (ms) after each WORD on chanted header lines (team 07-30); 0 = off
     theme: 'dark',           // projector theme: 'dark' (black bg) or 'light' (white bg) — #37
     fullscreenText: '',      // announcement text for the full-screen text box
     breakMinutes: 10,        // break timer duration (minutes)
@@ -52,6 +53,7 @@
       headerBpmDrop: CHANT_DEFAULTS.headerBpmDrop,
       saramAratiCountdown: CHANT_DEFAULTS.saramAratiCountdown,
       perSyllableTiming: CHANT_DEFAULTS.perSyllableTiming,
+      headerWordGapMs: CHANT_DEFAULTS.headerWordGapMs,
       theme: CHANT_DEFAULTS.theme,
       fullscreenText: CHANT_DEFAULTS.fullscreenText,
       breakMinutes: CHANT_DEFAULTS.breakMinutes,
@@ -76,6 +78,7 @@
           if (typeof parsed.headerBpmDrop === 'number') merged.headerBpmDrop = parsed.headerBpmDrop;
           if (typeof parsed.saramAratiCountdown === 'boolean') merged.saramAratiCountdown = parsed.saramAratiCountdown;
           if (typeof parsed.perSyllableTiming === 'boolean') merged.perSyllableTiming = parsed.perSyllableTiming;
+          if (typeof parsed.headerWordGapMs === 'number') merged.headerWordGapMs = parsed.headerWordGapMs;
           if (parsed.theme === 'dark' || parsed.theme === 'light') merged.theme = parsed.theme;
           if (typeof parsed.fullscreenText === 'string') merged.fullscreenText = parsed.fullscreenText;
           if (typeof parsed.breakMinutes === 'number') merged.breakMinutes = parsed.breakMinutes;
@@ -132,7 +135,8 @@
       anustubhBeats: chantSettings.anustubhBeats,
       tristubhBeats: chantSettings.tristubhBeats,
       uvacaPauseBeats: chantSettings.uvacaPauseBeats,
-      perSyllableTiming: chantSettings.perSyllableTiming
+      perSyllableTiming: chantSettings.perSyllableTiming,
+      headerWordGapMs: chantSettings.headerWordGapMs
     });
     // Projector theme — dark (black bg) / light (white bg) — #37
     sendToProjector('theme', { theme: chantSettings.theme });
@@ -577,7 +581,8 @@
     var elems = renderer.getSyllableElements();
     var el = elems[index];
     var beats = el ? (parseInt(el.dataset.beats, 10) || 1) : 1;
-    sendToProjector('syllable-update', { index: index, state: state, beatMs: beatMs, durationMs: beats * beatMs });
+    var extraMs = el ? (parseFloat(el.dataset.extraMs) || 0) : 0;
+    sendToProjector('syllable-update', { index: index, state: state, beatMs: beatMs, durationMs: beats * beatMs + extraMs });
   });
 
   // Sections whose END is a hard stop: rendering pauses on the last page
@@ -1042,6 +1047,8 @@
     if (fldSaramCd) fldSaramCd.value = chantSettings.saramAratiCountdown ? 'on' : 'off';
     var fldPerSyl = document.getElementById('set-per-syllable');
     if (fldPerSyl) fldPerSyl.value = chantSettings.perSyllableTiming ? 'on' : 'off';
+    var fldWordGap = document.getElementById('set-header-word-gap');
+    if (fldWordGap) fldWordGap.value = chantSettings.headerWordGapMs;
     if (fldFsText) fldFsText.value = chantSettings.fullscreenText || '';
     if (fldBreakMinutes) fldBreakMinutes.value = chantSettings.breakMinutes;
     if (fldTheme) fldTheme.value = chantSettings.theme;
@@ -1100,6 +1107,8 @@
     if (fldSaramCdS) chantSettings.saramAratiCountdown = fldSaramCdS.value !== 'off';
     var fldPerSylS = document.getElementById('set-per-syllable');
     if (fldPerSylS) chantSettings.perSyllableTiming = fldPerSylS.value !== 'off';
+    var fldWordGapS = document.getElementById('set-header-word-gap');
+    if (fldWordGapS) chantSettings.headerWordGapMs = Math.round(clampNum(fldWordGapS.value, 0, 500, CHANT_DEFAULTS.headerWordGapMs));
     if (fldFsText) chantSettings.fullscreenText = fldFsText.value;
     if (fldBreakMinutes) chantSettings.breakMinutes = Math.round(clampNum(fldBreakMinutes.value, 1, 120, CHANT_DEFAULTS.breakMinutes));
     if (fldTheme) chantSettings.theme = (fldTheme.value === 'light') ? 'light' : 'dark';

--- a/src/operator.js
+++ b/src/operator.js
@@ -29,8 +29,9 @@
     sarvadharmanPauseBeats: 3, // pause between colophon and sarvadharmān slide (mātrās) — #40
     headerBpmDrop: 40,       // internal bpm drop on header slides (= 10 BPM), all chapters — #47
     saramAratiCountdown: true, // countdown before Gita Sāram / Ārati recitation (OFF = header -> recitation directly)
-    perSyllableTiming: true, // Case 2 (team 07-30): pointer dwells per guru/laghu weight; OFF = line-average glide
-    headerWordGapMs: 2,      // pause (ms) after each WORD on chanted header lines (team 07-30); 0 = off
+    pacingVersion: 'B',      // A = parayana baseline (even glide, no word gaps);
+                             // B = experimental (per-syllable guru/laghu timing, syllable display, header word gaps)
+    headerWordGapMs: 2,      // pause (ms) after each WORD on chanted header lines — applies in version B only; 0 = off
     theme: 'dark',           // projector theme: 'dark' (black bg) or 'light' (white bg) — #37
     fullscreenText: '',      // announcement text for the full-screen text box
     breakMinutes: 10,        // break timer duration (minutes)
@@ -52,7 +53,7 @@
       sarvadharmanPauseBeats: CHANT_DEFAULTS.sarvadharmanPauseBeats,
       headerBpmDrop: CHANT_DEFAULTS.headerBpmDrop,
       saramAratiCountdown: CHANT_DEFAULTS.saramAratiCountdown,
-      perSyllableTiming: CHANT_DEFAULTS.perSyllableTiming,
+      pacingVersion: CHANT_DEFAULTS.pacingVersion,
       headerWordGapMs: CHANT_DEFAULTS.headerWordGapMs,
       theme: CHANT_DEFAULTS.theme,
       fullscreenText: CHANT_DEFAULTS.fullscreenText,
@@ -77,7 +78,8 @@
           if (typeof parsed.sarvadharmanPauseBeats === 'number') merged.sarvadharmanPauseBeats = parsed.sarvadharmanPauseBeats;
           if (typeof parsed.headerBpmDrop === 'number') merged.headerBpmDrop = parsed.headerBpmDrop;
           if (typeof parsed.saramAratiCountdown === 'boolean') merged.saramAratiCountdown = parsed.saramAratiCountdown;
-          if (typeof parsed.perSyllableTiming === 'boolean') merged.perSyllableTiming = parsed.perSyllableTiming;
+          if (parsed.pacingVersion === 'A' || parsed.pacingVersion === 'B') merged.pacingVersion = parsed.pacingVersion;
+          else if (typeof parsed.perSyllableTiming === 'boolean') merged.pacingVersion = parsed.perSyllableTiming ? 'B' : 'A'; // legacy toggle
           if (typeof parsed.headerWordGapMs === 'number') merged.headerWordGapMs = parsed.headerWordGapMs;
           if (parsed.theme === 'dark' || parsed.theme === 'light') merged.theme = parsed.theme;
           if (typeof parsed.fullscreenText === 'string') merged.fullscreenText = parsed.fullscreenText;
@@ -135,8 +137,10 @@
       anustubhBeats: chantSettings.anustubhBeats,
       tristubhBeats: chantSettings.tristubhBeats,
       uvacaPauseBeats: chantSettings.uvacaPauseBeats,
-      perSyllableTiming: chantSettings.perSyllableTiming,
-      headerWordGapMs: chantSettings.headerWordGapMs
+      // The A/B switch maps onto the two renderer knobs: version A reproduces
+      // the parayana-baseline behavior exactly (even glide, no word gaps).
+      perSyllableTiming: chantSettings.pacingVersion !== 'A',
+      headerWordGapMs: chantSettings.pacingVersion !== 'A' ? chantSettings.headerWordGapMs : 0
     });
     // Projector theme — dark (black bg) / light (white bg) — #37
     sendToProjector('theme', { theme: chantSettings.theme });
@@ -1045,8 +1049,8 @@
     if (fldHeaderBpmDrop) fldHeaderBpmDrop.value = chantSettings.headerBpmDrop;
     var fldSaramCd = document.getElementById('set-saram-arati-cd');
     if (fldSaramCd) fldSaramCd.value = chantSettings.saramAratiCountdown ? 'on' : 'off';
-    var fldPerSyl = document.getElementById('set-per-syllable');
-    if (fldPerSyl) fldPerSyl.value = chantSettings.perSyllableTiming ? 'on' : 'off';
+    var fldPacing = document.getElementById('set-pacing-version');
+    if (fldPacing) fldPacing.value = chantSettings.pacingVersion === 'A' ? 'A' : 'B';
     var fldWordGap = document.getElementById('set-header-word-gap');
     if (fldWordGap) fldWordGap.value = chantSettings.headerWordGapMs;
     if (fldFsText) fldFsText.value = chantSettings.fullscreenText || '';
@@ -1105,8 +1109,8 @@
     if (fldHeaderBpmDrop) chantSettings.headerBpmDrop = Math.round(clampNum(fldHeaderBpmDrop.value, 0, 80, CHANT_DEFAULTS.headerBpmDrop));
     var fldSaramCdS = document.getElementById('set-saram-arati-cd');
     if (fldSaramCdS) chantSettings.saramAratiCountdown = fldSaramCdS.value !== 'off';
-    var fldPerSylS = document.getElementById('set-per-syllable');
-    if (fldPerSylS) chantSettings.perSyllableTiming = fldPerSylS.value !== 'off';
+    var fldPacingS = document.getElementById('set-pacing-version');
+    if (fldPacingS) chantSettings.pacingVersion = fldPacingS.value === 'A' ? 'A' : 'B';
     var fldWordGapS = document.getElementById('set-header-word-gap');
     if (fldWordGapS) chantSettings.headerWordGapMs = Math.round(clampNum(fldWordGapS.value, 0, 500, CHANT_DEFAULTS.headerWordGapMs));
     if (fldFsText) chantSettings.fullscreenText = fldFsText.value;

--- a/src/operator.js
+++ b/src/operator.js
@@ -141,6 +141,8 @@
       pacingMode: chantSettings.pacingVersion,
       headerWordGapMs: chantSettings.pacingVersion !== 'A' ? chantSettings.headerWordGapMs : 0
     });
+    // Version-scoped data: bcOnly ślokas exist in B/C only (no-op in this repo).
+    dataLayer.setPacingMode(chantSettings.pacingVersion);
     // The projector renders its own copy of every page, and versions differ in
     // STAR COUNTS (C: one per mātrā) — it must always share the operator's
     // pacing config or pointer indexes would land on the wrong element.
@@ -497,7 +499,9 @@
         // (re-entering would schedule a second reveal mid-countdown).
         if (manualTitlePending || countdownActive) return;
         manualTitlePending = true;
-        var isHold = HOLD_BLANK_AFTER_COUNTDOWN[secId] === true;
+        // The black hold is version-A behavior only (team 08-30): in B/C the
+        // sections render like any other section.
+        var isHold = HOLD_BLANK_AFTER_COUNTDOWN[secId] === true && chantSettings.pacingVersion === 'A';
         syncProjectorPage(); // render the title behind the selection blank...
         setTimeout(function() {
           // ...and reveal it once the projector has had time to draw it —
@@ -669,7 +673,7 @@
             var beginRecitation = function() {
               // Sāram/Ārati: hold on a BLANK slide after the countdown — no text,
               // no pointer, nothing plays until the operator acts.
-              if (HOLD_BLANK_AFTER_COUNTDOWN[nextId]) {
+              if (HOLD_BLANK_AFTER_COUNTDOWN[nextId] && chantSettings.pacingVersion === 'A') {
                 var fc = firstRecitationPage();
                 var tot = dataLayer.getPageCount();
                 if (fc < tot) showPage(fc); // pre-position so Play starts the first content page
@@ -1032,7 +1036,7 @@
     '2': 320, '3': 340, '4': 340, '5': 340, '6': 340, '7': 340, '8': 340,
     '9': 340, '10': 340, '11': 340, '12': 340, '13': 340, '14': 340,
     '15': 340, '16': 340, '17': 340, '18': 340, gita_mahatmyam: 320,
-    kshama_prarthana: 300
+    kshama_prarthana: 300, gita_saram: 320, gita_arati: 320
   };
   function effectiveSectionBpm(id) {
     if (typeof chantSettings.sectionBpm[id] === 'number') return chantSettings.sectionBpm[id];

--- a/src/operator.js
+++ b/src/operator.js
@@ -29,8 +29,7 @@
     sarvadharmanPauseBeats: 3, // pause between colophon and sarvadharmān slide (mātrās) — #40
     headerBpmDrop: 40,       // internal bpm drop on header slides (= 10 BPM), all chapters — #47
     saramAratiCountdown: true, // countdown before Gita Sāram / Ārati recitation (OFF = header -> recitation directly)
-    pacingVersion: 'B',      // A = parayana baseline (even glide, no word gaps);
-                             // B = experimental (per-syllable guru/laghu timing, syllable display, header word gaps)
+    pacingVersion: 'C',      // A = parayana baseline (even glide) · B = per-syllable dwell · C = mātrā stars, constant pointer
     headerWordGapMs: 2,      // pause (ms) after each WORD on chanted header lines — applies in version B only; 0 = off
     theme: 'dark',           // projector theme: 'dark' (black bg) or 'light' (white bg) — #37
     fullscreenText: '',      // announcement text for the full-screen text box
@@ -78,7 +77,7 @@
           if (typeof parsed.sarvadharmanPauseBeats === 'number') merged.sarvadharmanPauseBeats = parsed.sarvadharmanPauseBeats;
           if (typeof parsed.headerBpmDrop === 'number') merged.headerBpmDrop = parsed.headerBpmDrop;
           if (typeof parsed.saramAratiCountdown === 'boolean') merged.saramAratiCountdown = parsed.saramAratiCountdown;
-          if (parsed.pacingVersion === 'A' || parsed.pacingVersion === 'B') merged.pacingVersion = parsed.pacingVersion;
+          if (parsed.pacingVersion === 'A' || parsed.pacingVersion === 'B' || parsed.pacingVersion === 'C') merged.pacingVersion = parsed.pacingVersion;
           else if (typeof parsed.perSyllableTiming === 'boolean') merged.pacingVersion = parsed.perSyllableTiming ? 'B' : 'A'; // legacy toggle
           if (typeof parsed.headerWordGapMs === 'number') merged.headerWordGapMs = parsed.headerWordGapMs;
           if (parsed.theme === 'dark' || parsed.theme === 'light') merged.theme = parsed.theme;
@@ -137,9 +136,16 @@
       anustubhBeats: chantSettings.anustubhBeats,
       tristubhBeats: chantSettings.tristubhBeats,
       uvacaPauseBeats: chantSettings.uvacaPauseBeats,
-      // The A/B switch maps onto the two renderer knobs: version A reproduces
-      // the parayana-baseline behavior exactly (even glide, no word gaps).
-      perSyllableTiming: chantSettings.pacingVersion !== 'A',
+      // A/B/C switch: A reproduces the parayana baseline exactly (even glide,
+      // no word gaps); B = per-syllable dwell; C = mātrā stars.
+      pacingMode: chantSettings.pacingVersion,
+      headerWordGapMs: chantSettings.pacingVersion !== 'A' ? chantSettings.headerWordGapMs : 0
+    });
+    // The projector renders its own copy of every page, and versions differ in
+    // STAR COUNTS (C: one per mātrā) — it must always share the operator's
+    // pacing config or pointer indexes would land on the wrong element.
+    sendToProjector('pace-config', {
+      pacingMode: chantSettings.pacingVersion,
       headerWordGapMs: chantSettings.pacingVersion !== 'A' ? chantSettings.headerWordGapMs : 0
     });
     // Projector theme — dark (black bg) / light (white bg) — #37
@@ -1050,7 +1056,7 @@
     var fldSaramCd = document.getElementById('set-saram-arati-cd');
     if (fldSaramCd) fldSaramCd.value = chantSettings.saramAratiCountdown ? 'on' : 'off';
     var fldPacing = document.getElementById('set-pacing-version');
-    if (fldPacing) fldPacing.value = chantSettings.pacingVersion === 'A' ? 'A' : 'B';
+    if (fldPacing) fldPacing.value = chantSettings.pacingVersion;
     var fldWordGap = document.getElementById('set-header-word-gap');
     if (fldWordGap) fldWordGap.value = chantSettings.headerWordGapMs;
     if (fldFsText) fldFsText.value = chantSettings.fullscreenText || '';
@@ -1110,7 +1116,7 @@
     var fldSaramCdS = document.getElementById('set-saram-arati-cd');
     if (fldSaramCdS) chantSettings.saramAratiCountdown = fldSaramCdS.value !== 'off';
     var fldPacingS = document.getElementById('set-pacing-version');
-    if (fldPacingS) chantSettings.pacingVersion = fldPacingS.value === 'A' ? 'A' : 'B';
+    if (fldPacingS) chantSettings.pacingVersion = (fldPacingS.value === 'A' || fldPacingS.value === 'B') ? fldPacingS.value : 'C';
     var fldWordGapS = document.getElementById('set-header-word-gap');
     if (fldWordGapS) chantSettings.headerWordGapMs = Math.round(clampNum(fldWordGapS.value, 0, 500, CHANT_DEFAULTS.headerWordGapMs));
     if (fldFsText) chantSettings.fullscreenText = fldFsText.value;
@@ -1162,7 +1168,16 @@
     var curChId = dataLayer.getCurrentChapterId();
     if (curChId !== null && dataLayer.getPage(currentPage)) {
       var savedState = animator.getState();
+      // Pacing versions differ in element COUNTS (C: one star per mātrā), so the
+      // position must be carried across the re-render as (line, fraction) — the
+      // same mapping the display-mode toggle uses — not as a raw index.
+      var savedLinePos = renderer.getLinePosition(savedState.currentIndex, savedState.progress);
       renderer.renderPage(dataLayer.getPage(currentPage));
+      if (savedState.currentIndex >= 0 && savedLinePos) {
+        var remapped = renderer.mapLinePosition(savedLinePos);
+        savedState.currentIndex = remapped.index;
+        savedState.progress = remapped.progress;
+      }
       animator.restore(savedState);
       renderer.prefetchPage(currentPage + 1, curChId);
       var rs = animator.getState();

--- a/src/preload.js
+++ b/src/preload.js
@@ -6,7 +6,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       'render-page', 'syllable-update', 'animation-reset',
       'countdown', 'display-mode', 'spm-change',
       'show-instruction', 'dismiss-instruction',
-      'verse-zoom', 'theme',
+      'verse-zoom', 'theme', 'pace-config',
       'fullscreen-text', 'break-timer',
       'open-projector', 'close-projector'
     ];
@@ -19,7 +19,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       'render-page', 'syllable-update', 'animation-reset',
       'countdown', 'display-mode', 'spm-change',
       'show-instruction', 'dismiss-instruction',
-      'verse-zoom', 'theme',
+      'verse-zoom', 'theme', 'pace-config',
       'fullscreen-text', 'break-timer',
       'projector-status'
     ];

--- a/src/projector.html
+++ b/src/projector.html
@@ -115,6 +115,11 @@
     .syllable.done {
       color: var(--done);
     }
+    /* English per-syllable mode (Case 2): restore the inter-word space the
+       syllable tokenizer consumed. Asterisk mode is unaffected (no word-end). */
+    .syllable.word-end {
+      margin-right: 0.35em;
+    }
     .verse-marker {
       display: inline-block;
       margin-left: 0.3em;

--- a/src/projector.js
+++ b/src/projector.js
@@ -11,6 +11,7 @@
   // current page under the new config.
   window.electronAPI.on('pace-config', function(data) {
     renderer.setPaceConfig(data);
+    if (data.pacingMode) dataLayer.setPacingMode(data.pacingMode); // bcOnly ślokas (B/C-only content)
     if (lastRenderReq) {
       var replay = lastRenderReq;
       dataLayer.fetchChapter(replay.chapter).then(function() {

--- a/src/projector.js
+++ b/src/projector.js
@@ -3,9 +3,27 @@
 (function() {
   var pageReady = false; // true once render-page has completed
   var pendingUpdates = []; // queued syllable-updates that arrived before page was ready
+  var lastRenderReq = null; // last render-page request — replayed after a pace-config change
+
+  // pace-config: the operator's pacing version (A/B/C) — the versions differ in
+  // STAR COUNTS (C: one per mātrā), so the projector must render with the same
+  // config or pointer indexes would land on the wrong element. Re-render the
+  // current page under the new config.
+  window.electronAPI.on('pace-config', function(data) {
+    renderer.setPaceConfig(data);
+    if (lastRenderReq) {
+      var replay = lastRenderReq;
+      dataLayer.fetchChapter(replay.chapter).then(function() {
+        if (replay.displayMode) renderer.setMode(replay.displayMode);
+        var page = dataLayer.getPage(replay.pageIndex);
+        if (page) renderer.renderPage(page);
+      }).catch(function() {});
+    }
+  });
 
   // render-page: load chapter and render a specific page
   window.electronAPI.on('render-page', function(data) {
+    lastRenderReq = data;
     pageReady = false;
     dataLayer.fetchChapter(data.chapter).then(function() {
       if (data.displayMode) {

--- a/src/shared.js
+++ b/src/shared.js
@@ -642,11 +642,20 @@ const dataLayer = (function() {
   // (the default regular parayana). When set, next/prev traversal skips
   // chapters not in the subset, but manual jumps to any chapter still work.
   let activeChapters = null;
+  // Pacing version (A/B/C) — ślokas flagged bcOnly in the data exist only in
+  // versions B and C; version A (the parayana base) skips them. This repo's
+  // data carries no bcOnly flags (its parayana base always had the Sāram/Ārati
+  // content), so the filter is a no-op here — kept for code parity.
+  let pacingMode = 'C';
+  function setPacingMode(mode) {
+    if (mode === 'A' || mode === 'B' || mode === 'C') pacingMode = mode;
+  }
 
   function groupIntoPages(shlokas, chapterLineEndPause) {
     const result = [];
 
     for (const shloka of shlokas) {
+      if (shloka.bcOnly === true && pacingMode === 'A') continue;
       const headerEntries = shloka.entry.filter(e => e.sty === 'fh' || e.sty === 'sh' || e.sty === 'th' || e.sty === 'uh');
       const regularEntries = shloka.entry.filter(e => e.sty !== 'fh' && e.sty !== 'sh' && e.sty !== 'th' && e.sty !== 'uh');
 
@@ -789,7 +798,7 @@ const dataLayer = (function() {
     return null;
   }
 
-  return { fetchChapter, getPage, getPageCount, getChapterName, getCurrentChapterId, getNextChapterId, getPrevChapterId, setActiveChapters, getFirstActiveChapterId, CHAPTER_ORDER };
+  return { fetchChapter, getPage, getPageCount, getChapterName, getCurrentChapterId, getNextChapterId, getPrevChapterId, setActiveChapters, getFirstActiveChapterId, setPacingMode, CHAPTER_ORDER };
 })();
 
 // ============================================================

--- a/src/shared.js
+++ b/src/shared.js
@@ -747,7 +747,12 @@ const renderer = (function() {
   //   anustubhBeats / tristubhBeats — meter-aware verse line-end pause (#20/#21; tristubh 4.5 per #36.2)
   // A page line may also carry an explicit `pauseBeats` that overrides the meter default (#36.3).
   //   uvacaPauseBeats — pause after each "uvāca" speaker label (#39; default 4)
-  const paceConfig = { headerPauseBeats: 3, anustubhBeats: 2, tristubhBeats: 3, uvacaPauseBeats: 3 };
+  //   perSyllableTiming — Case 2 (team 07-30): every syllable span carries its
+  //     OWN guru/laghu weight, so the pointer dwells 2 mātrās on a guru and 1 on
+  //     a laghu, matching the chant's real rhythm. OFF = the original line-average
+  //     glide (every asterisk gets the line's mean beat value). Line totals are
+  //     identical either way — only the motion WITHIN the line changes.
+  const paceConfig = { headerPauseBeats: 3, anustubhBeats: 2, tristubhBeats: 3, uvacaPauseBeats: 3, perSyllableTiming: true };
   // Sections whose title HEADER slide is a plain static title (text in both
   // display modes, no pointer). Kept minimal: only the new Pūrṇam / Samarpana
   // titles — existing section headers keep their current behavior.
@@ -772,6 +777,7 @@ const renderer = (function() {
     if (typeof cfg.anustubhBeats === 'number') paceConfig.anustubhBeats = cfg.anustubhBeats;
     if (typeof cfg.tristubhBeats === 'number') paceConfig.tristubhBeats = cfg.tristubhBeats;
     if (typeof cfg.uvacaPauseBeats === 'number') paceConfig.uvacaPauseBeats = cfg.uvacaPauseBeats;
+    if (typeof cfg.perSyllableTiming === 'boolean') paceConfig.perSyllableTiming = cfg.perSyllableTiming;
   }
 
   // Double-buffer: render next page into the hidden buffer, swap on advance
@@ -870,17 +876,43 @@ const renderer = (function() {
       const analyzer = hasDevanagari ? prosody : iastProsody;
 
       if (currentMode === 'english') {
-        // English mode: show IAST text, one span per line with total beats
-        const displayText = line.iast || line.text;
-        const tokens = analyzer.analyzeLine(analyzeText);
-        const totalBeats = tokens.reduce((sum, t) => sum + t.beats, 0);
-
+        // English mode: show IAST text.
+        // perSyllableTiming ON (Case 2, team 07-30): one span PER SYLLABLE of
+        // the displayed text, each with its own guru/laghu weight — the pointer
+        // moves syllable-by-syllable over the words exactly as in asterisk
+        // mode, so a reader can verify the pointer sits on the syllable being
+        // sung. The IAST text itself is analyzed so display and timing are the
+        // same token stream. OFF: the original single span per line with the
+        // line's total beats.
+        //
         // Each data entry = one pāda (display line). Long pādas are NOT split
         // into two display lines — fitLines() shrinks them to fit. This matches
         // the reference deck (each pāda on one line) and the web build
         // (index.html), and fixes the "Dhyana line mixups" (feedback #10–19)
         // that came from breaking a pāda at the wrong mid-pāda point.
-        {
+        const displayText = line.iast || line.text;
+        if (paceConfig.perSyllableTiming) {
+          const eAnalyzer = /[\u0900-\u097F]/.test(displayText) ? prosody : iastProsody;
+          const eTokens = eAnalyzer.analyzeLine(displayText);
+          for (let ei = 0; ei < eTokens.length; ei++) {
+            const token = eTokens[ei];
+            const span = document.createElement('span');
+            span.dataset.beats = token.beats;
+            if (token.isMarker) {
+              span.className = 'verse-marker';
+              span.textContent = token.text;
+            } else {
+              // word-end: restores the inter-word space the tokenizer consumed
+              span.className = 'syllable' + (token.wordEnd ? ' word-end' : '');
+              span.dataset.index = elements.length;
+              span.textContent = token.text;
+            }
+            elements.push(span);
+            lineDiv.appendChild(span);
+          }
+        } else {
+          const tokens = analyzer.analyzeLine(analyzeText);
+          const totalBeats = tokens.reduce((sum, t) => sum + t.beats, 0);
           const span = document.createElement('span');
           span.className = 'syllable';
           span.dataset.index = elements.length;
@@ -890,11 +922,13 @@ const renderer = (function() {
           lineDiv.appendChild(span);
         }
       } else {
-        // Asterisk mode: one asterisk per syllable. For EVEN pointer movement,
-        // every syllable carries the line's AVERAGE beat value (not its own
-        // guru/laghu weight), so the hand glides at a constant rate across all
-        // asterisks while the line's total time \u2014 and thus the set tempo \u2014 is
-        // preserved. Markers (dandas) keep their own beats for the line-end pause.
+        // Asterisk mode: one asterisk per syllable.
+        // perSyllableTiming ON (Case 2, team 07-30): each asterisk carries its
+        // own guru/laghu weight — the pointer dwells on long syllables the way
+        // the chant does. OFF: the original EVEN glide — every syllable carries
+        // the line's AVERAGE beat value. The line's total time — and thus the
+        // set tempo — is identical either way. Markers (dandas) keep their own
+        // beats for the line-end pause.
         const tokens = analyzer.analyzeLine(analyzeText);
         const sylToks = tokens.filter(t => !t.isMarker);
         const avgBeats = sylToks.length
@@ -911,7 +945,7 @@ const renderer = (function() {
             span.textContent = token.text;
             elements.push(span);
           } else {
-            span.dataset.beats = avgBeats;
+            span.dataset.beats = paceConfig.perSyllableTiming ? token.beats : avgBeats;
             span.className = 'syllable';
             span.dataset.index = elements.length;
             span.textContent = '\u2731';

--- a/src/shared.js
+++ b/src/shared.js
@@ -752,7 +752,11 @@ const renderer = (function() {
   //     a laghu, matching the chant's real rhythm. OFF = the original line-average
   //     glide (every asterisk gets the line's mean beat value). Line totals are
   //     identical either way — only the motion WITHIN the line changes.
-  const paceConfig = { headerPauseBeats: 3, anustubhBeats: 2, tristubhBeats: 3, uvacaPauseBeats: 3, perSyllableTiming: true };
+  //   headerWordGapMs — tiny pause inserted after the last syllable of each WORD
+  //     on chanted header lines (team 07-30: "atha · śrīmad · bhagavad ·  gītā"),
+  //     plus a visible gap between the word groups of asterisks. Milliseconds,
+  //     fixed (not tempo-scaled). 0 disables.
+  const paceConfig = { headerPauseBeats: 3, anustubhBeats: 2, tristubhBeats: 3, uvacaPauseBeats: 3, perSyllableTiming: true, headerWordGapMs: 2 };
   // Sections whose title HEADER slide is a plain static title (text in both
   // display modes, no pointer). Kept minimal: only the new Pūrṇam / Samarpana
   // titles — existing section headers keep their current behavior.
@@ -778,6 +782,7 @@ const renderer = (function() {
     if (typeof cfg.tristubhBeats === 'number') paceConfig.tristubhBeats = cfg.tristubhBeats;
     if (typeof cfg.uvacaPauseBeats === 'number') paceConfig.uvacaPauseBeats = cfg.uvacaPauseBeats;
     if (typeof cfg.perSyllableTiming === 'boolean') paceConfig.perSyllableTiming = cfg.perSyllableTiming;
+    if (typeof cfg.headerWordGapMs === 'number') paceConfig.headerWordGapMs = cfg.headerWordGapMs;
   }
 
   // Double-buffer: render next page into the hidden buffer, swap on advance
@@ -836,7 +841,9 @@ const renderer = (function() {
           elements.push(span);
           lineDiv.appendChild(span);
         } else {
-          // Asterisk mode: one ✱ per syllable, all animated
+          // Asterisk mode: one ✱ per syllable, all animated. Word ends get a
+          // visible gap between the asterisk groups and a small extra pause
+          // (headerWordGapMs) so the words of a header read separately (#07-30).
           for (let ti = 0; ti < hTokens.length; ti++) {
             const token = hTokens[ti];
             const span = document.createElement('span');
@@ -846,7 +853,10 @@ const renderer = (function() {
               span.textContent = token.text;
               elements.push(span);
             } else {
-              span.className = 'syllable';
+              span.className = 'syllable' + (token.wordEnd ? ' word-end' : '');
+              if (token.wordEnd && paceConfig.headerWordGapMs > 0) {
+                span.dataset.extraMs = paceConfig.headerWordGapMs;
+              }
               span.dataset.index = elements.length;
               span.textContent = '✱';
               elements.push(span);
@@ -1320,7 +1330,8 @@ const animator = (function() {
     // preserved. In English mode the single line-span carries the line's total
     // beats. parseFloat because averaged beats can be fractional.
     const beats = parseFloat(el.dataset.beats) || 1;
-    const durationMs = beats * getBeatMs();
+    // extraMs: fixed word-gap pause on chanted header word ends (#07-30)
+    const durationMs = beats * getBeatMs() + (parseFloat(el.dataset.extraMs) || 0);
     elementStartedAt = Date.now();
     elementDurationMs = durationMs;
     frozenProgress = 0;

--- a/src/shared.js
+++ b/src/shared.js
@@ -808,16 +808,17 @@ const renderer = (function() {
   //   anustubhBeats / tristubhBeats — meter-aware verse line-end pause (#20/#21; tristubh 4.5 per #36.2)
   // A page line may also carry an explicit `pauseBeats` that overrides the meter default (#36.3).
   //   uvacaPauseBeats — pause after each "uvāca" speaker label (#39; default 4)
-  //   perSyllableTiming — Case 2 (team 07-30): every syllable span carries its
-  //     OWN guru/laghu weight, so the pointer dwells 2 mātrās on a guru and 1 on
-  //     a laghu, matching the chant's real rhythm. OFF = the original line-average
-  //     glide (every asterisk gets the line's mean beat value). Line totals are
-  //     identical either way — only the motion WITHIN the line changes.
+  //   pacingMode — the A/B/C pacing version (team 07-30/08-30). Line totals are
+  //     identical in all three — only the motion WITHIN a line changes:
+  //     'A' — parayana baseline: even glide; English = one span per line.
+  //     'B' — per-syllable guru/laghu dwell; English = one span per syllable.
+  //     'C' — mātrā stars: one star per MĀTRĀ, constant pointer motion;
+  //           English renders as in B (book text untouched).
   //   headerWordGapMs — tiny pause inserted after the last syllable of each WORD
   //     on chanted header lines (team 07-30: "atha · śrīmad · bhagavad ·  gītā"),
   //     plus a visible gap between the word groups of asterisks. Milliseconds,
   //     fixed (not tempo-scaled). 0 disables.
-  const paceConfig = { headerPauseBeats: 3, anustubhBeats: 2, tristubhBeats: 3, uvacaPauseBeats: 3, perSyllableTiming: true, headerWordGapMs: 2 };
+  const paceConfig = { headerPauseBeats: 3, anustubhBeats: 2, tristubhBeats: 3, uvacaPauseBeats: 3, pacingMode: 'C', headerWordGapMs: 2 };
   // Sections whose title HEADER slide is a plain static title (text in both
   // display modes, no pointer). Kept minimal: only the new Pūrṇam / Samarpana
   // titles — existing section headers keep their current behavior.
@@ -842,7 +843,8 @@ const renderer = (function() {
     if (typeof cfg.anustubhBeats === 'number') paceConfig.anustubhBeats = cfg.anustubhBeats;
     if (typeof cfg.tristubhBeats === 'number') paceConfig.tristubhBeats = cfg.tristubhBeats;
     if (typeof cfg.uvacaPauseBeats === 'number') paceConfig.uvacaPauseBeats = cfg.uvacaPauseBeats;
-    if (typeof cfg.perSyllableTiming === 'boolean') paceConfig.perSyllableTiming = cfg.perSyllableTiming;
+    if (cfg.pacingMode === 'A' || cfg.pacingMode === 'B' || cfg.pacingMode === 'C') paceConfig.pacingMode = cfg.pacingMode;
+    else if (typeof cfg.perSyllableTiming === 'boolean') paceConfig.pacingMode = cfg.perSyllableTiming ? 'B' : 'A'; // legacy
     if (typeof cfg.headerWordGapMs === 'number') paceConfig.headerWordGapMs = cfg.headerWordGapMs;
   }
 
@@ -902,27 +904,37 @@ const renderer = (function() {
           elements.push(span);
           lineDiv.appendChild(span);
         } else {
-          // Asterisk mode: one ✱ per syllable, all animated. Word ends get a
-          // visible gap between the asterisk groups and a small extra pause
-          // (headerWordGapMs) so the words of a header read separately (#07-30).
+          // Asterisk mode: all animated. Word ends get a visible gap between
+          // the asterisk groups and a small extra pause (headerWordGapMs) so
+          // the words of a header read separately (#07-30).
+          // Mode C: one ✱ per MĀTRĀ (a guru contributes two identical stars,
+          // each worth 1 mātrā) — constant pointer motion. A/B: one ✱ per
+          // syllable with the token's own beats (headers were never averaged).
           for (let ti = 0; ti < hTokens.length; ti++) {
             const token = hTokens[ti];
-            const span = document.createElement('span');
-            span.dataset.beats = token.beats;
             if (token.isMarker) {
+              const span = document.createElement('span');
+              span.dataset.beats = token.beats;
               span.className = 'verse-marker';
               span.textContent = token.text;
               elements.push(span);
-            } else {
-              span.className = 'syllable' + (token.wordEnd ? ' word-end' : '');
-              if (token.wordEnd && paceConfig.headerWordGapMs > 0) {
+              lineDiv.appendChild(span);
+              continue;
+            }
+            const starCount = paceConfig.pacingMode === 'C' ? Math.max(1, Math.round(token.beats)) : 1;
+            for (let mi = 0; mi < starCount; mi++) {
+              const span = document.createElement('span');
+              span.dataset.beats = paceConfig.pacingMode === 'C' ? 1 : token.beats;
+              const isLastOfToken = mi === starCount - 1;
+              span.className = 'syllable' + (token.wordEnd && isLastOfToken ? ' word-end' : '');
+              if (token.wordEnd && isLastOfToken && paceConfig.headerWordGapMs > 0) {
                 span.dataset.extraMs = paceConfig.headerWordGapMs;
               }
               span.dataset.index = elements.length;
               span.textContent = '✱';
               elements.push(span);
+              lineDiv.appendChild(span);
             }
-            lineDiv.appendChild(span);
           }
         }
 
@@ -962,7 +974,7 @@ const renderer = (function() {
         // (index.html), and fixes the "Dhyana line mixups" (feedback #10–19)
         // that came from breaking a pāda at the wrong mid-pāda point.
         const displayText = line.iast || line.text;
-        if (paceConfig.perSyllableTiming) {
+        if (paceConfig.pacingMode !== 'A') {
           const eAnalyzer = /[\u0900-\u097F]/.test(displayText) ? prosody : iastProsody;
           const eTokens = eAnalyzer.analyzeLine(displayText);
           for (let ei = 0; ei < eTokens.length; ei++) {
@@ -1008,22 +1020,30 @@ const renderer = (function() {
 
         for (let ti = 0; ti < tokens.length; ti++) {
           const token = tokens[ti];
-          const span = document.createElement('span');
 
           if (token.isMarker) {
+            const span = document.createElement('span');
             span.dataset.beats = token.beats;
             span.className = 'verse-marker';
             span.textContent = token.text;
             elements.push(span);
-          } else {
-            span.dataset.beats = paceConfig.perSyllableTiming ? token.beats : avgBeats;
+            lineDiv.appendChild(span);
+            continue;
+          }
+
+          // By pacing version (line totals identical in all): A = average glide,
+          // B = own guru/laghu weight, C = one star per mātrā (constant motion).
+          const starCount = paceConfig.pacingMode === 'C' ? Math.max(1, Math.round(token.beats)) : 1;
+          for (let mi = 0; mi < starCount; mi++) {
+            const span = document.createElement('span');
+            span.dataset.beats = paceConfig.pacingMode === 'C' ? 1
+              : (paceConfig.pacingMode === 'B' ? token.beats : avgBeats);
             span.className = 'syllable';
             span.dataset.index = elements.length;
             span.textContent = '\u2731';
             elements.push(span);
+            lineDiv.appendChild(span);
           }
-
-          lineDiv.appendChild(span);
         }
       }
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -425,7 +425,28 @@ const prosody = (function() {
       }
     }
 
+    resegmentCodas(tokens);
     return tokens;
+  }
+
+  // Conjunct resegmentation (#07-30): the splitter attaches a whole conjunct to
+  // the FOLLOWING syllable (अ|न्त|व|त्तु), but the chanted akṣaras close the
+  // previous syllable with the conjunct's dead consonant (अन्|त|वत्|तु —
+  // an|ta|vat|tu). Move ONE dead consonant (C + virāma) of a syllable-initial
+  // cluster onto the previous syllable of the same word. DISPLAY-ONLY: token
+  // count, beats, guru/laghu and word flags are untouched (the weights already
+  // sat on the correct positions via the guru-by-position rule).
+  function resegmentCodas(tokens) {
+    for (let ti = 1; ti < tokens.length; ti++) {
+      const prev = tokens[ti - 1];
+      const cur = tokens[ti];
+      if (cur.isMarker || prev.isMarker || prev.wordEnd) continue;
+      const m = cur.text.match(/^([\u0915-\u0939\u0958-\u095F]\u094D)([\u0915-\u0939\u0958-\u095F].*)$/);
+      if (m) {
+        prev.text += m[1];
+        cur.text = m[2];
+      }
+    }
   }
 
   return { splitSyllables, isGuru, analyzeLine };
@@ -553,7 +574,47 @@ const iastProsody = (function() {
         tokens[ti - 1].beats = 2;
       }
     }
+    resegmentCodas(tokens);
     return tokens;
+  }
+
+  // Conjunct resegmentation (#07-30) — IAST twin of the Devanagari rule: a
+  // syllable-initial consonant cluster gives its FIRST consonant to the previous
+  // syllable of the same word (a|nta|va|ttu → an|ta|vat|tu; ka|rmā → kar|mā;
+  // śā|stra → śās|tra). Aspirate digraphs (kh, gh, th, dh, ...) count as one
+  // consonant. DISPLAY-ONLY: token count, beats and flags are untouched.
+  const IAST_CONS_UNITS = ['kh','gh','ch','jh','ṭh','ḍh','th','dh','ph','bh',
+    'ṅ','ñ','ṇ','ṭ','ḍ','ś','ṣ','ḷ','k','g','c','j','t','d','n','p','b','m',
+    'y','r','l','v','s','h'];
+  function leadingConsUnits(text) {
+    const units = [];
+    let rest = text;
+    let matched = true;
+    while (matched && rest) {
+      matched = false;
+      for (let ci = 0; ci < IAST_CONS_UNITS.length; ci++) {
+        const c = IAST_CONS_UNITS[ci];
+        if (rest.startsWith(c)) {
+          units.push(c);
+          rest = rest.slice(c.length);
+          matched = true;
+          break;
+        }
+      }
+    }
+    return { units: units, rest: rest };
+  }
+  function resegmentCodas(tokens) {
+    for (let ti = 1; ti < tokens.length; ti++) {
+      const prev = tokens[ti - 1];
+      const cur = tokens[ti];
+      if (cur.isMarker || prev.isMarker || prev.wordEnd) continue;
+      const lead = leadingConsUnits(cur.text);
+      if (lead.units.length >= 2) {
+        prev.text += lead.units[0];
+        cur.text = lead.units.slice(1).join('') + lead.rest;
+      }
+    }
   }
 
   return { splitSyllables, isGuru, analyzeLine };


### PR DESCRIPTION
The post-parayana pacing experiments (team calls 07-30 / 08-30), all behind a single Settings switch:

**Pacing version A/B/C** (Settings dropdown, synced to the projector via a new whitelisted pace-config IPC):
- **A — Parayana baseline**: exactly the event behavior (even pointer glide, single-span English lines, no word gaps)
- **B — Guru/laghu rhythm**: every syllable span carries its own weight — the pointer dwells 2 matras on a guru; English mode renders one span per syllable of the book text
- **C — Matra stars (default)**: one star per MATRA (a guru occupies two identical stars), constant pointer motion; English as in B

Also included:
- Conjunct resegmentation: syllable labels read as chanted aksharas (an|ta|vat|tu) — display-only, corpus-verified zero timing change
- Header word gaps (Settings-tunable ms, B/C only)
- Gita Saram/Arati: default BPM 320; black hold is version-A behavior only — in B/C they render like any other section
- Gita Arati restructure: whole section per slide (6 lines incl. doubled 3rd pada + full 'om jaya bhagavadgite' refrain line), pallavi x2 ending, 'om jaya bhagavadgite' x3 close, all || om jaya || markers removed

Line totals are bit-identical across A/B/C. Extensive CDP E2E on both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhJ3cyLrFuGiRiBe9oCFPv