### PR TITLE
chore: bump version to 0.13.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gita-pacer",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gita-pacer",
-      "version": "0.13.19",
+      "version": "0.13.20",
       "devDependencies": {
         "electron": "^35.0.0",
         "electron-builder": "^26.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gita-pacer",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "main": "main.js",
   "scripts": {
     "start": "electron .",


### PR DESCRIPTION
Version bump for the A/B/C pacing release (PR #74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhJ3cyLrFuGiRiBe9oCFPv