### PR TITLE
09-02 batch: manual Saram/Arati, pallavi x1, configurable last-sloka pause (v0.13.21)

### DIFF
--- a/data/gita_arati.json
+++ b/data/gita_arati.json
@@ -383,8 +383,7 @@
           "shlNbr": "00",
           "sty": ""
         }
-      ],
-      "repeat": 2
+      ]
     },
     {
       "shlokaNum": "pallavi",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gita-pacer",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gita-pacer",
-      "version": "0.13.20",
+      "version": "0.13.21",
       "devDependencies": {
         "electron": "^35.0.0",
         "electron-builder": "^26.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gita-pacer",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/src/operator.html
+++ b/src/operator.html
@@ -384,6 +384,9 @@ hr { border: none; border-top: 1px solid #333; margin: 0; }
       <label for="set-sarvadharman-pause">Pause before Sarva Dharman (mātrās)</label>
       <input type="number" id="set-sarvadharman-pause" min="0" max="12" step="0.5">
 
+      <label for="set-last-sloka-pause">Pause After Last Sloka (mātrās, ch 1–18)</label>
+      <input type="number" id="set-last-sloka-pause" min="3" max="7" step="0.5">
+
       <label for="set-header-bpm-drop">Header slowdown (BPM drop)</label>
       <input type="number" id="set-header-bpm-drop" min="0" max="80" step="1">
 

--- a/src/operator.js
+++ b/src/operator.js
@@ -27,6 +27,7 @@
     uvacaPauseBeats: 3,      // pause after each uvāca speaker label (mātrās) — team table 2026-07-15
     colophonPauseSeconds: 2, // pause before the colophon ("om tatsaditi") slide — #41
     sarvadharmanPauseBeats: 3, // pause between colophon and sarvadharmān slide (mātrās) — #40
+    lastSlokaPauseBeats: 5,  // pause after the LAST sloka of ch 1–18, before "om tatsaditi" (team 09-02; 3–7)
     headerBpmDrop: 40,       // internal bpm drop on header slides (= 10 BPM), all chapters — #47
     saramAratiCountdown: true, // countdown before Gita Sāram / Ārati recitation (OFF = header -> recitation directly)
     pacingVersion: 'C',      // A = parayana baseline (even glide) · B = per-syllable dwell · C = mātrā stars, constant pointer
@@ -50,6 +51,7 @@
       uvacaPauseBeats: CHANT_DEFAULTS.uvacaPauseBeats,
       colophonPauseSeconds: CHANT_DEFAULTS.colophonPauseSeconds,
       sarvadharmanPauseBeats: CHANT_DEFAULTS.sarvadharmanPauseBeats,
+      lastSlokaPauseBeats: CHANT_DEFAULTS.lastSlokaPauseBeats,
       headerBpmDrop: CHANT_DEFAULTS.headerBpmDrop,
       saramAratiCountdown: CHANT_DEFAULTS.saramAratiCountdown,
       pacingVersion: CHANT_DEFAULTS.pacingVersion,
@@ -75,6 +77,7 @@
           if (typeof parsed.uvacaPauseBeats === 'number') merged.uvacaPauseBeats = parsed.uvacaPauseBeats;
           if (typeof parsed.colophonPauseSeconds === 'number') merged.colophonPauseSeconds = parsed.colophonPauseSeconds;
           if (typeof parsed.sarvadharmanPauseBeats === 'number') merged.sarvadharmanPauseBeats = parsed.sarvadharmanPauseBeats;
+          if (typeof parsed.lastSlokaPauseBeats === 'number') merged.lastSlokaPauseBeats = parsed.lastSlokaPauseBeats;
           if (typeof parsed.headerBpmDrop === 'number') merged.headerBpmDrop = parsed.headerBpmDrop;
           if (typeof parsed.saramAratiCountdown === 'boolean') merged.saramAratiCountdown = parsed.saramAratiCountdown;
           if (parsed.pacingVersion === 'A' || parsed.pacingVersion === 'B' || parsed.pacingVersion === 'C') merged.pacingVersion = parsed.pacingVersion;
@@ -136,6 +139,7 @@
       anustubhBeats: chantSettings.anustubhBeats,
       tristubhBeats: chantSettings.tristubhBeats,
       uvacaPauseBeats: chantSettings.uvacaPauseBeats,
+      lastSlokaPauseBeats: chantSettings.lastSlokaPauseBeats,
       // A/B/C switch: A reproduces the parayana baseline exactly (even glide,
       // no word gaps); B = per-syllable dwell; C = mātrā stars.
       pacingMode: chantSettings.pacingVersion,
@@ -523,9 +527,11 @@
             projectorBlanked = true;
           } else {
             // Begin recitation directly at the first content page — the title
-            // already had its display time before the countdown.
+            // already had its display time before the countdown. Manual
+            // sections (Sāram/Ārati in B/C) only SHOW the page: the presenter
+            // drives with Next/Previous, the pointer stays off.
             if (fc < tot) showPage(fc);
-            animator.play();
+            if (!inManualSection(secId)) animator.play();
           }
         };
         setTimeout(function() {
@@ -552,6 +558,9 @@
         animator.play();
       });
     } else {
+      // Manual sections: Play never starts the pointer — slides are advanced
+      // with Next/Previous only.
+      if (inManualSection(dataLayer.getCurrentChapterId())) return;
       animator.play();
     }
   }
@@ -620,6 +629,13 @@
   // Sāram/Ārati flow: after their countdown the projector holds on a BLANK slide
   // until the operator acts (Play reveals and starts; any page change reveals).
   var HOLD_BLANK_AFTER_COUNTDOWN = { gita_saram: true, gita_arati: true };
+  // Team 09-02: in versions B/C, Gita Sāram & Ārati are PRESENTER-DRIVEN —
+  // no automatic pointer movement or auto-advance; the presenter flips slides
+  // with Next/Previous. (Version A keeps its parayana behavior untouched.)
+  var MANUAL_POINTER_OFF = { gita_saram: true, gita_arati: true };
+  function inManualSection(chId) {
+    return MANUAL_POINTER_OFF[chId] === true && chantSettings.pacingVersion !== 'A';
+  }
   var blankHoldActive = false;
 
   // --- Auto-advance: when animator reaches end of page, go to next and resume ---
@@ -690,7 +706,7 @@
               var total = dataLayer.getPageCount();
               if (firstContent < total) showPage(firstContent);
               syncProjectorPage();
-              animator.play();
+              if (!inManualSection(nextId)) animator.play();
             };
             // Optional countdown skip (Settings) for Gita Sāram / Ārati only:
             // OFF = header -> recitation directly.
@@ -1056,6 +1072,8 @@
     if (fldUvacaPause) fldUvacaPause.value = chantSettings.uvacaPauseBeats;
     if (fldColophonPause) fldColophonPause.value = chantSettings.colophonPauseSeconds;
     if (fldSarvaPause) fldSarvaPause.value = chantSettings.sarvadharmanPauseBeats;
+    var fldLastSloka = document.getElementById('set-last-sloka-pause');
+    if (fldLastSloka) fldLastSloka.value = chantSettings.lastSlokaPauseBeats;
     if (fldHeaderBpmDrop) fldHeaderBpmDrop.value = chantSettings.headerBpmDrop;
     var fldSaramCd = document.getElementById('set-saram-arati-cd');
     if (fldSaramCd) fldSaramCd.value = chantSettings.saramAratiCountdown ? 'on' : 'off';
@@ -1116,6 +1134,8 @@
     if (fldUvacaPause) chantSettings.uvacaPauseBeats = clampNum(fldUvacaPause.value, 0, 12, CHANT_DEFAULTS.uvacaPauseBeats);
     if (fldColophonPause) chantSettings.colophonPauseSeconds = clampNum(fldColophonPause.value, 0, 10, CHANT_DEFAULTS.colophonPauseSeconds);
     if (fldSarvaPause) chantSettings.sarvadharmanPauseBeats = clampNum(fldSarvaPause.value, 0, 12, CHANT_DEFAULTS.sarvadharmanPauseBeats);
+    var fldLastSlokaS = document.getElementById('set-last-sloka-pause');
+    if (fldLastSlokaS) chantSettings.lastSlokaPauseBeats = clampNum(fldLastSlokaS.value, 3, 7, CHANT_DEFAULTS.lastSlokaPauseBeats);
     if (fldHeaderBpmDrop) chantSettings.headerBpmDrop = Math.round(clampNum(fldHeaderBpmDrop.value, 0, 80, CHANT_DEFAULTS.headerBpmDrop));
     var fldSaramCdS = document.getElementById('set-saram-arati-cd');
     if (fldSaramCdS) chantSettings.saramAratiCountdown = fldSaramCdS.value !== 'off';

--- a/src/shared.js
+++ b/src/shared.js
@@ -735,6 +735,17 @@ const dataLayer = (function() {
     currentChapterId = id;
     chapterName = data.name || '';
     pages = groupIntoPages(data.shloka || [], data.lineEndPauseBeats);
+    // Chapters 1–18: mark the LAST sloka page (the verse page right before the
+    // "om tatsaditi" closer) so the renderer can apply the configurable
+    // Pause-After-Last-Sloka (team 09-02) to its final line.
+    var chNum = parseInt(id, 10);
+    if (!isNaN(chNum) && chNum >= 1 && chNum <= 18) {
+      for (var pi = 0; pi < pages.length - 1; pi++) {
+        if (pages[pi + 1].isCloser && !pages[pi].isHeader && !pages[pi].isCloser) {
+          pages[pi].lastSlokaOfChapter = true;
+        }
+      }
+    }
 
     // Prefetch next chapter in background
     var idx = CHAPTER_ORDER.indexOf(id);
@@ -827,7 +838,9 @@ const renderer = (function() {
   //     on chanted header lines (team 07-30: "atha · śrīmad · bhagavad ·  gītā"),
   //     plus a visible gap between the word groups of asterisks. Milliseconds,
   //     fixed (not tempo-scaled). 0 disables.
-  const paceConfig = { headerPauseBeats: 3, anustubhBeats: 2, tristubhBeats: 3, uvacaPauseBeats: 3, pacingMode: 'C', headerWordGapMs: 2 };
+  //   lastSlokaPauseBeats — pause (mātrās) after the LAST sloka of each Gita
+  //     chapter (1–18), before the "om tatsaditi" slide (team 09-02; 3–7, default 5).
+  const paceConfig = { headerPauseBeats: 3, anustubhBeats: 2, tristubhBeats: 3, uvacaPauseBeats: 3, pacingMode: 'C', headerWordGapMs: 2, lastSlokaPauseBeats: 5 };
   // Sections whose title HEADER slide is a plain static title (text in both
   // display modes, no pointer). Kept minimal: only the new Pūrṇam / Samarpana
   // titles — existing section headers keep their current behavior.
@@ -855,6 +868,7 @@ const renderer = (function() {
     if (cfg.pacingMode === 'A' || cfg.pacingMode === 'B' || cfg.pacingMode === 'C') paceConfig.pacingMode = cfg.pacingMode;
     else if (typeof cfg.perSyllableTiming === 'boolean') paceConfig.pacingMode = cfg.perSyllableTiming ? 'B' : 'A'; // legacy
     if (typeof cfg.headerWordGapMs === 'number') paceConfig.headerWordGapMs = cfg.headerWordGapMs;
+    if (typeof cfg.lastSlokaPauseBeats === 'number') paceConfig.lastSlokaPauseBeats = cfg.lastSlokaPauseBeats;
   }
 
   // Double-buffer: render next page into the hidden buffer, swap on advance
@@ -1091,6 +1105,18 @@ const renderer = (function() {
       }
 
       target.appendChild(lineDiv);
+    }
+
+    // Pause-After-Last-Sloka (team 09-02): on the last sloka page of a Gita
+    // chapter, the FINAL line's end pause uses the configurable value instead
+    // of the meter default, giving breathing room before "om tatsaditi".
+    if (pageData.lastSlokaOfChapter) {
+      for (let li = elements.length - 1; li >= 0; li--) {
+        if (elements[li].dataset.lineEnd) {
+          elements[li].dataset.lineEndPauseBeats = String(paceConfig.lastSlokaPauseBeats);
+          break;
+        }
+      }
     }
 
     // Stamp a mode-independent line number on every element (#8): element indices


### PR DESCRIPTION
Team requests 2026-09-02:

1. **Gita Saram & Arati are presenter-driven in versions B/C** — the pointer never moves automatically and nothing auto-advances; after the title/countdown the first content page is shown and the presenter uses Next/Previous. Play is a no-op mid-section. Version A untouched.
2. **Gita Arati**: the full pallavi now appears once (the (2/2) repetition removed); the om-jaya x3 ending follows directly.
3. **'Pause After Last Sloka' setting** (3–7 mātrās, default 5) — applied to the final line of the last sloka of every chapter 1–18, right before the om-tatsaditi slide. All other pauses unchanged.

CDP E2E 15/15 on both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhJ3cyLrFuGiRiBe9oCFPv