### PR TITLE
09-02 fixes: tatsaditi 70% zoom, A-English number stop, word-gap 0, C hybrid (v0.13.22)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gita-pacer",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gita-pacer",
-      "version": "0.13.21",
+      "version": "0.13.22",
       "devDependencies": {
         "electron": "^35.0.0",
         "electron-builder": "^26.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gita-pacer",
-  "version": "0.13.21",
+  "version": "0.13.22",
   "main": "main.js",
   "scripts": {
     "start": "electron .",

--- a/src/operator.js
+++ b/src/operator.js
@@ -14,7 +14,7 @@
   // older revision are migrated on load: per-section tempo overrides are dropped
   // (they were frozen pre-fill hints, see saveSettings), and pause/slow-down
   // values still at their OLD defaults are upgraded to the new defaults.
-  var SETTINGS_REV = 3;
+  var SETTINGS_REV = 4;
 
   var CHANT_DEFAULTS = {
     colophonBpmDrop: 20,     // internal bpm drop on colophon / ending pages
@@ -31,7 +31,7 @@
     headerBpmDrop: 40,       // internal bpm drop on header slides (= 10 BPM), all chapters — #47
     saramAratiCountdown: true, // countdown before Gita Sāram / Ārati recitation (OFF = header -> recitation directly)
     pacingVersion: 'C',      // A = parayana baseline (even glide) · B = per-syllable dwell · C = mātrā stars, constant pointer
-    headerWordGapMs: 2,      // pause (ms) after each WORD on chanted header lines — applies in version B only; 0 = off
+    headerWordGapMs: 0,      // pause (ms) after each WORD on chanted header lines — applies in version B only; 0 = off
     theme: 'dark',           // projector theme: 'dark' (black bg) or 'light' (white bg) — #37
     fullscreenText: '',      // announcement text for the full-screen text box
     breakMinutes: 10,        // break timer duration (minutes)
@@ -93,6 +93,7 @@
             if (merged.uvacaPauseBeats === 2 || merged.uvacaPauseBeats === 4) merged.uvacaPauseBeats = CHANT_DEFAULTS.uvacaPauseBeats;
             if (merged.headerBpmDrop === 20) merged.headerBpmDrop = CHANT_DEFAULTS.headerBpmDrop;
             if (merged.countdownSeconds === 5) merged.countdownSeconds = CHANT_DEFAULTS.countdownSeconds;  // 5 → 3, team 07-24
+            if (merged.headerWordGapMs === 2) merged.headerWordGapMs = CHANT_DEFAULTS.headerWordGapMs;  // 2 → 0, team 09-02
           }
           if (isCurrentRev && parsed.sectionBpm && typeof parsed.sectionBpm === 'object') {
             for (var k in parsed.sectionBpm) {

--- a/src/projector.html
+++ b/src/projector.html
@@ -120,6 +120,12 @@
     .syllable.word-end {
       margin-right: 0.35em;
     }
+    /* Om tatsaditi (closer) slide in English script: 70% zoom so the namaskara
+       instruction card never overlaps the text (team 09-02). */
+    #verse-container-a.closer-zoom, #verse-container-b.closer-zoom {
+      transform: scale(0.7);
+      transform-origin: center center;
+    }
     .verse-marker {
       display: inline-block;
       margin-left: 0.3em;

--- a/src/projector.html
+++ b/src/projector.html
@@ -131,6 +131,12 @@
       margin-left: 0.3em;
       color: var(--marker);
     }
+    /* Version A English: the trailing sloka number, excluded from the pointer
+       sweep (team 09-02). Rendered like the rest of the line. */
+    .line-number-tail {
+      display: inline-block;
+      margin-left: 0.3em;
+    }
     #pointer {
       position: absolute;
       font-size: 36px;

--- a/src/shared.js
+++ b/src/shared.js
@@ -887,6 +887,10 @@ const renderer = (function() {
     target.textContent = '';
     // Colophon (closer) pages are center-aligned; all other pages left-aligned.
     target.classList.toggle('centered', !!pageData.isCloser);
+    // Om tatsaditi slide in ENGLISH script: render at 70% so the namaskara
+    // instruction card never overlaps the long transliterated lines (team
+    // 09-02). All pacing versions; asterisk mode unaffected.
+    target.classList.toggle('closer-zoom', !!pageData.isCloser && currentMode === 'english');
     const elements = [];
 
     for (const line of pageData.lines) {

--- a/src/shared.js
+++ b/src/shared.js
@@ -840,7 +840,7 @@ const renderer = (function() {
   //     fixed (not tempo-scaled). 0 disables.
   //   lastSlokaPauseBeats — pause (mātrās) after the LAST sloka of each Gita
   //     chapter (1–18), before the "om tatsaditi" slide (team 09-02; 3–7, default 5).
-  const paceConfig = { headerPauseBeats: 3, anustubhBeats: 2, tristubhBeats: 3, uvacaPauseBeats: 3, pacingMode: 'C', headerWordGapMs: 2, lastSlokaPauseBeats: 5 };
+  const paceConfig = { headerPauseBeats: 3, anustubhBeats: 2, tristubhBeats: 3, uvacaPauseBeats: 3, pacingMode: 'C', headerWordGapMs: 0, lastSlokaPauseBeats: 5 };
   // Sections whose title HEADER slide is a plain static title (text in both
   // display modes, no pointer). Kept minimal: only the new Pūrṇam / Samarpana
   // titles — existing section headers keep their current behavior.

--- a/src/shared.js
+++ b/src/shared.js
@@ -985,6 +985,14 @@ const renderer = (function() {
       const analyzeText = hasDevanagari ? line.text : (line.iast || line.text);
       const analyzer = hasDevanagari ? prosody : iastProsody;
 
+      // Version C hybrid (team 09-02): verse ślokas render like version A —
+      // even glide in asterisk mode, single-span sweep in English — everywhere
+      // EXCEPT Gita Sāram/Ārati (kept as-is) and the om-tatsaditi closers
+      // (mātrā stars). Section headers keep their C treatment above.
+      const vSection = dataLayer.getCurrentChapterId();
+      const effMode = (paceConfig.pacingMode === 'C' && !pageData.isCloser &&
+        vSection !== 'gita_saram' && vSection !== 'gita_arati') ? 'A' : paceConfig.pacingMode;
+
       if (currentMode === 'english') {
         // English mode: show IAST text.
         // perSyllableTiming ON (Case 2, team 07-30): one span PER SYLLABLE of
@@ -1001,7 +1009,7 @@ const renderer = (function() {
         // (index.html), and fixes the "Dhyana line mixups" (feedback #10–19)
         // that came from breaking a pāda at the wrong mid-pāda point.
         const displayText = line.iast || line.text;
-        if (paceConfig.pacingMode !== 'A') {
+        if (effMode !== 'A') {
           const eAnalyzer = /[\u0900-\u097F]/.test(displayText) ? prosody : iastProsody;
           const eTokens = eAnalyzer.analyzeLine(displayText);
           for (let ei = 0; ei < eTokens.length; ei++) {
@@ -1076,11 +1084,11 @@ const renderer = (function() {
 
           // By pacing version (line totals identical in all): A = average glide,
           // B = own guru/laghu weight, C = one star per mātrā (constant motion).
-          const starCount = paceConfig.pacingMode === 'C' ? Math.max(1, Math.round(token.beats)) : 1;
+          const starCount = effMode === 'C' ? Math.max(1, Math.round(token.beats)) : 1;
           for (let mi = 0; mi < starCount; mi++) {
             const span = document.createElement('span');
-            span.dataset.beats = paceConfig.pacingMode === 'C' ? 1
-              : (paceConfig.pacingMode === 'B' ? token.beats : avgBeats);
+            span.dataset.beats = effMode === 'C' ? 1
+              : (effMode === 'B' ? token.beats : avgBeats);
             span.className = 'syllable';
             span.dataset.index = elements.length;
             span.textContent = '\u2731';

--- a/src/shared.js
+++ b/src/shared.js
@@ -1023,13 +1023,29 @@ const renderer = (function() {
         } else {
           const tokens = analyzer.analyzeLine(analyzeText);
           const totalBeats = tokens.reduce((sum, t) => sum + t.beats, 0);
+          // Version A: the whole line is ONE swept span. A trailing sloka
+          // NUMBER (||N||) is split into a separate non-animated tail span so
+          // the pointer's sweep ends at the last chanted syllable and never
+          // travels over the digits (team 09-02). Timing is unchanged: the
+          // number's mātrās remain inside totalBeats on the swept span.
+          // Mid-line dandas and non-numeric markers stay in the swept text.
+          let sweepText = displayText;
+          let tailText = null;
+          const mTail = displayText.match(/^(.*?)\s*(\|\|\s*\d+\s*\|\|)\s*$/);
+          if (mTail && mTail[1]) { sweepText = mTail[1]; tailText = mTail[2]; }
           const span = document.createElement('span');
           span.className = 'syllable';
           span.dataset.index = elements.length;
           span.dataset.beats = totalBeats;
-          span.textContent = displayText;
+          span.textContent = sweepText;
           elements.push(span);
           lineDiv.appendChild(span);
+          if (tailText) {
+            const tail = document.createElement('span');
+            tail.className = 'line-number-tail';
+            tail.textContent = tailText;
+            lineDiv.appendChild(tail);
+          }
         }
       } else {
         // Asterisk mode: one asterisk per syllable.


### PR DESCRIPTION
Four team requests (2026-09-02):

1. **Om tatsaditi at 70% zoom in English script** — the namaskara instruction card no longer overlaps the long transliterated lines (all pacing versions; asterisk mode unaffected).
2. **Version A English: pointer stops before the śloka number** — the trailing ||N|| is a non-animated tail span; the sweep ends at the last chanted syllable with timing bit-identical (the number's mātrās stay in the line's beats).
3. **Header word gap defaults to 0 ms** (SETTINGS_REV 4 migration; field remains in Settings).
4. **Version C hybrid** — verse ślokas across all sections render like version A (even glide, single-span English); section headers and om-tatsaditi keep mātrā stars; Gita Sāram/Ārati stay presenter-driven. A and B untouched.

All verified via CDP E2E incl. live pointer-position measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhJ3cyLrFuGiRiBe9oCFPv